### PR TITLE
Improve test runner

### DIFF
--- a/dev-resources/octocat/test/octocat/broken_namespace_test.clj
+++ b/dev-resources/octocat/test/octocat/broken_namespace_test.clj
@@ -1,5 +1,0 @@
-(ns octocat.broken-namespace-test
-  (:require  [midje.sweet :as midje]))
-
-;; This is intentional for testing purposes. See integration.test-test.
-(boom!)

--- a/dev-resources/octocat/test/octocat/broken_namespace_test.clj
+++ b/dev-resources/octocat/test/octocat/broken_namespace_test.clj
@@ -1,0 +1,5 @@
+(ns octocat.broken-namespace-test
+  (:require  [midje.sweet :as midje]))
+
+;; This is intentional for testing purposes. See integration.test-test.
+(boom!)

--- a/integration/integration/test_test.clj
+++ b/integration/integration/test_test.clj
@@ -49,15 +49,6 @@ it's possible to jump to the correct position of the test in question"
                (read-line-from file line)
                => #"\(\+ 2 3\) => 6"))
 
-       (fact "returns an error result when the test namespace is broken"
-             (send-message {:op "midje-test-ns"
-                            :ns "octocat.broken-namespace-test"})
-             => (match (list {:results
-                              {:octocat.broken-namespace-test [{:line 5
-                                                                :type "error"}]}
-                              :summary {:error 1 :ns 1}}
-                             {:status ["done"]})))
-
        (fact "runs the specified test"
              (send-message {:op     "midje-test"
                             :ns     "octocat.arithmetic-test"
@@ -93,12 +84,24 @@ the middleware returns an error"
              (first (send-message {:op "midje-test"}))
              => (match {:status (m/in-any-order ["done" "error" "no-ns" "no-source"])}))
 
+       (fact "returns an error result when the test namespace is broken"
+             (send-message {:op     "midje-test"
+                            :ns     "octocat.arithmetic-test"
+                            :source "(ns octocat.arithmetic-test
+(:require [midje.sweet :refer :all]))
+
+(boom!)"})
+             => (match (list {:results
+                              {:octocat.arithmetic-test [{:line 4
+                                                          :type "error"}]}
+                              :summary {:error 1 :ns 1}}
+                             {:status ["done"]})))
+
        (fact "runs all tests in the project"
              (send-message {:op "midje-test-all"})
-             => (match (list {:results {:octocat.arithmetic-test       (complement empty?)
-                                        :octocat.side-effects-test     (complement empty?)
-                                        :octocat.broken-namespace-test (complement empty?)}
-                              :summary {:error 2 :fact 5 :fail 2 :ns 3 :pass 3 :skip 0 :test 6}}
+             => (match (list {:results {:octocat.arithmetic-test   (complement empty?)
+                                        :octocat.side-effects-test (complement empty?)}
+                              :summary {:error 1 :fact 5 :fail 2 :ns 2 :pass 3 :skip 0 :test 6}}
                              {:status ["done"]})))
 
        (fact "re-runs tests that didn't pass in the previous execution"

--- a/integration/integration/test_test.clj
+++ b/integration/integration/test_test.clj
@@ -17,9 +17,9 @@
 
 (facts "about running tests"
 
-       (fact "the REPL is up and running")
-       (send-message {:op "eval" :code "(+ 2 1)"})
-       => (match (list {:value "3"} {:status ["done"]}))
+       (fact "the REPL is up and running"
+             (send-message {:op "eval" :code "(+ 2 1)"})
+             => (match (list {:value "3"} {:status ["done"]})))
 
        (fact "runs all tests in the specified namespace"
              (send-message {:op "midje-test-ns" :ns "octocat.arithmetic-test"})
@@ -56,9 +56,9 @@ it's possible to jump to the correct position of the test in question"
                              {:status ["done"]})))
 
        (fact "runs the specified test"
-             (send-message {:op         "midje-test"
-                            :ns         "octocat.arithmetic-test"
-                            :test-forms "(fact \"this is a crazy arithmetic\"
+             (send-message {:op     "midje-test"
+                            :ns     "octocat.arithmetic-test"
+                            :source "(fact \"this is a crazy arithmetic\"
              (+ 2 3) => 6)"})
              => (match (list {:results
                               {:octocat.arithmetic-test
@@ -72,10 +72,23 @@ it's possible to jump to the correct position of the test in question"
                               :summary {:error 0 :fact 1 :fail 1 :ns 1 :pass 0 :skip 0 :test 1}}
                              {:status ["done"]})))
 
-       (fact "when the parameters ns and/or test-forms are missing in the message,
+       (fact "when a line is provided, it will be used to determine the correct position of the failure in question"
+             (send-message {:op     "midje-test"
+                            :ns     "octocat.arithmetic-test"
+                            :source "(fact \"this is a crazy arithmetic\"
+             (+ 2 3) => 6)"
+                            :line   9})
+             => (match (list {:results
+                              {:octocat.arithmetic-test
+                               [{:type "fail"
+                                 :line 10}]}
+                              :summary {:error 0 :fact 1 :fail 1 :ns 1 :pass 0 :skip 0 :test 1}}
+                             {:status ["done"]})))
+
+       (fact "when the parameters ns and/or source are missing in the message,
 the middleware returns an error"
              (first (send-message {:op "midje-test"}))
-             => (match {:status (m/in-any-order ["done" "error" "no-ns" "no-test-forms"])}))
+             => (match {:status (m/in-any-order ["done" "error" "no-ns" "no-source"])}))
 
        (fact "runs all tests in the project"
              (send-message {:op "midje-test-all"})

--- a/integration/integration/test_test.clj
+++ b/integration/integration/test_test.clj
@@ -49,13 +49,10 @@ it's possible to jump to the correct position of the test in question"
                (read-line-from file line)
                => #"\(\+ 2 3\) => 6"))
 
-       (fact "returns an error result when the test namespace is broken"
-             (send-message {:op "midje-test-ns"
-                            :ns "octocat.broken-namespace-test"})
-             => (match (list {:results
-                              {:octocat.broken-namespace-test [{:line 5
-                                                                :type "error"}]}
-                              :summary {:error 1 :ns 1}}
+       (fact "re-runs tests that didn't pass in the previous execution"
+             (send-message {:op "midje-retest"})
+             => (match (list {:results (complement empty?)
+                              :summary {:error 1 :fact 3 :fail 2 :ns 1 :pass 1 :skip 0 :test 4}}
                              {:status ["done"]})))
 
        (fact "runs the specified test"
@@ -95,18 +92,9 @@ the middleware returns an error"
 
        (fact "runs all tests in the project"
              (send-message {:op "midje-test-all"})
-             => (match (list {:results {:octocat.arithmetic-test       (complement empty?)
-                                        :octocat.side-effects-test     (complement empty?)
-                                        :octocat.broken-namespace-test (complement empty?)}
-                              :summary {:error 2 :fact 5 :fail 2 :ns 3 :pass 3 :skip 0 :test 6}}
-                             {:status ["done"]})))
-
-       (fact "re-runs tests that didn't pass in the previous execution"
-             (send-message {:op "midje-test-ns" :ns "octocat.arithmetic-test"})
-             => irrelevant
-             (send-message {:op "midje-retest"})
-             => (match (list {:results (complement empty?)
-                              :summary {:error 1 :fact 3 :fail 2 :ns 1 :pass 1 :skip 0 :test 4}}
+             => (match (list {:results {:octocat.arithmetic-test   (complement empty?)
+                                        :octocat.side-effects-test (complement empty?)}
+                              :summary {:error 1 :fact 5 :fail 2 :ns 2 :pass 3 :skip 0 :test 6}}
                              {:status ["done"]})))
 
        (fact "gets the stacktrace of the given erring test"

--- a/integration/integration/test_test.clj
+++ b/integration/integration/test_test.clj
@@ -92,8 +92,9 @@ the middleware returns an error"
 
 (boom!)"})
              => (match (list {:results
-                              {:octocat.arithmetic-test [{:line 4
-                                                          :type "error"}]}
+                              {:octocat.arithmetic-test [{:error #"Unable to resolve symbol: boom! in this context"
+                                                          :line  4
+                                                          :type  "error"}]}
                               :summary {:error 1 :ns 1}}
                              {:status ["done"]})))
 

--- a/integration/integration/test_test.clj
+++ b/integration/integration/test_test.clj
@@ -24,7 +24,7 @@
        (fact "runs all tests in the specified namespace"
              (send-message {:op "midje-test-ns" :ns "octocat.arithmetic-test"})
              => (match (list {:results (complement empty?)
-                              :summary {:error 1 :fact 4 :fail 2 :ns 1 :pass 2 :skip 0 :test 5}}
+                              :summary {:check 5 :error 1 :fact 4 :fail 2 :ns 1 :pass 2 :to-do 0}}
                              {:status ["done"]})))
 
        (fact "when the ns is missing in the message, the middleware returns an error"
@@ -63,7 +63,7 @@ it's possible to jump to the correct position of the test in question"
                                  :expected "6\n"
                                  :actual   "5\n"
                                  :message  []}]}
-                              :summary {:error 0 :fact 1 :fail 1 :ns 1 :pass 0 :skip 0 :test 1}}
+                              :summary {:check 1 :error 0 :fact 1 :fail 1 :ns 1 :pass 0 :to-do 0}}
                              {:status ["done"]})))
 
        (fact "when a line is provided, it will be used to determine the correct position of the failure in question"
@@ -76,7 +76,7 @@ it's possible to jump to the correct position of the test in question"
                               {:octocat.arithmetic-test
                                [{:type "fail"
                                  :line 10}]}
-                              :summary {:error 0 :fact 1 :fail 1 :ns 1 :pass 0 :skip 0 :test 1}}
+                              :summary {:check 1 :error 0 :fact 1 :fail 1 :ns 1 :pass 0 :to-do 0}}
                              {:status ["done"]})))
 
        (fact "when the parameters ns and/or source are missing in the message,
@@ -101,7 +101,7 @@ the middleware returns an error"
              (send-message {:op "midje-test-all"})
              => (match (list {:results {:octocat.arithmetic-test   (complement empty?)
                                         :octocat.side-effects-test (complement empty?)}
-                              :summary {:error 1 :fact 5 :fail 2 :ns 2 :pass 3 :skip 0 :test 6}}
+                              :summary {:check 6 :error 1 :fact 5 :fail 2 :ns 2 :pass 3 :to-do 0}}
                              {:status ["done"]})))
 
        (fact "re-runs tests that didn't pass in the previous execution"
@@ -109,7 +109,7 @@ the middleware returns an error"
              => irrelevant
              (send-message {:op "midje-retest"})
              => (match (list {:results (complement empty?)
-                              :summary {:error 1 :fact 3 :fail 2 :ns 1 :pass 1 :skip 0 :test 4}}
+                              :summary {:check 4 :error 1 :fact 3 :fail 2 :ns 1 :pass 1 :to-do 0}}
                              {:status ["done"]})))
 
        (fact "gets the stacktrace of the given erring test"

--- a/integration/integration/test_test.clj
+++ b/integration/integration/test_test.clj
@@ -49,10 +49,13 @@ it's possible to jump to the correct position of the test in question"
                (read-line-from file line)
                => #"\(\+ 2 3\) => 6"))
 
-       (fact "re-runs tests that didn't pass in the previous execution"
-             (send-message {:op "midje-retest"})
-             => (match (list {:results (complement empty?)
-                              :summary {:error 1 :fact 3 :fail 2 :ns 1 :pass 1 :skip 0 :test 4}}
+       (fact "returns an error result when the test namespace is broken"
+             (send-message {:op "midje-test-ns"
+                            :ns "octocat.broken-namespace-test"})
+             => (match (list {:results
+                              {:octocat.broken-namespace-test [{:line 5
+                                                                :type "error"}]}
+                              :summary {:error 1 :ns 1}}
                              {:status ["done"]})))
 
        (fact "runs the specified test"
@@ -92,9 +95,18 @@ the middleware returns an error"
 
        (fact "runs all tests in the project"
              (send-message {:op "midje-test-all"})
-             => (match (list {:results {:octocat.arithmetic-test   (complement empty?)
-                                        :octocat.side-effects-test (complement empty?)}
-                              :summary {:error 1 :fact 5 :fail 2 :ns 2 :pass 3 :skip 0 :test 6}}
+             => (match (list {:results {:octocat.arithmetic-test       (complement empty?)
+                                        :octocat.side-effects-test     (complement empty?)
+                                        :octocat.broken-namespace-test (complement empty?)}
+                              :summary {:error 2 :fact 5 :fail 2 :ns 3 :pass 3 :skip 0 :test 6}}
+                             {:status ["done"]})))
+
+       (fact "re-runs tests that didn't pass in the previous execution"
+             (send-message {:op "midje-test-ns" :ns "octocat.arithmetic-test"})
+             => irrelevant
+             (send-message {:op "midje-retest"})
+             => (match (list {:results (complement empty?)
+                              :summary {:error 1 :fact 3 :fail 2 :ns 1 :pass 1 :skip 0 :test 4}}
                              {:status ["done"]})))
 
        (fact "gets the stacktrace of the given erring test"

--- a/src/midje_nrepl/middleware/test.clj
+++ b/src/midje_nrepl/middleware/test.clj
@@ -19,11 +19,11 @@
 
 (defn- test-reply [{:keys [ns line source] :or {line 1} :as message}]
   (let [namespace (symbol ns)
-        report    (test-runner/run-test namespace line source)]
+        report    (test-runner/run-test namespace source line)]
     (send-report message report)))
 
 (defn- retest-reply [message]
-  (->> (test-runner/re-run-failed-tests)
+  (->> (test-runner/re-run-non-passing-tests)
        (send-report message)))
 
 (defn- test-stacktrace-reply [{:keys [index ns print-fn transport] :as message}]

--- a/src/midje_nrepl/middleware/test.clj
+++ b/src/midje_nrepl/middleware/test.clj
@@ -17,9 +17,9 @@
         report    (test-runner/run-tests-in-ns namespace)]
     (send-report message report)))
 
-(defn- test-reply [{:keys [ns test-forms] :as message}]
+(defn- test-reply [{:keys [ns line source] :as message}]
   (let [namespace (symbol ns)
-        report    (test-runner/run-test namespace test-forms)]
+        report    (test-runner/run-test namespace line source)]
     (send-report message report)))
 
 (defn- retest-reply [message]

--- a/src/midje_nrepl/middleware/test.clj
+++ b/src/midje_nrepl/middleware/test.clj
@@ -17,7 +17,7 @@
         report    (test-runner/run-tests-in-ns namespace)]
     (send-report message report)))
 
-(defn- test-reply [{:keys [ns line source] :as message}]
+(defn- test-reply [{:keys [ns line source] :or {line 1} :as message}]
   (let [namespace (symbol ns)
         report    (test-runner/run-test namespace line source)]
     (send-report message report)))

--- a/src/midje_nrepl/nrepl.clj
+++ b/src/midje_nrepl/nrepl.clj
@@ -90,8 +90,10 @@
                :requires {"ns" "A string indicating the namespace containing the tests to be run."}}
               "midje-test"
               {:doc      "Runs a given Midje test (either an individual fact or facts)."
-               :requires {"ns"         "The namespace in which the fact(s) sent through `test-forms` should be evaluated."
-                          "test-forms" "The fact(s) to be run."}}
+               :requires {"ns"     "The namespace in which the fact(s) sent through `test-forms` should be evaluated."
+                          "source" "The fact(s) to be run."}
+               :optional
+               {"line" "The line number where the facts to be tested starts."}}
               "midje-retest"
               {:doc "Re-runs the tests that didn't pass in the last execution."}
               "midje-test-stacktrace"

--- a/src/midje_nrepl/project_info.clj
+++ b/src/midje_nrepl/project_info.clj
@@ -1,7 +1,8 @@
 (ns midje-nrepl.project-info
   (:require [clojure.java.io :as io]
             [clojure.tools.namespace.find :as namespace.find]
-            [orchard.classpath :as classpath])
+            [orchard.classpath :as classpath]
+            [orchard.namespace :as namespace])
   (:import [java.io FileReader PushbackReader]))
 
 (def ^:private leiningen-project-file "project.clj")
@@ -14,6 +15,11 @@
          (map #(.getPath %))
          (some (partial re-find pattern))
          boolean)))
+
+(defn file-for [namespace]
+  (some-> (name namespace)
+          namespace/ns-path
+          io/file))
 
 (defn- project-working-dir []
   (.getCanonicalFile (io/file ".")))

--- a/src/midje_nrepl/project_info.clj
+++ b/src/midje_nrepl/project_info.clj
@@ -16,7 +16,7 @@
          (some (partial re-find pattern))
          boolean)))
 
-(defn file-for [namespace]
+(defn file-for-ns [namespace]
   (some-> (name namespace)
           namespace/ns-path
           io/file))

--- a/src/midje_nrepl/reporter.clj
+++ b/src/midje_nrepl/reporter.clj
@@ -137,6 +137,7 @@
     (-> no-tests
         (assoc-in [:results ns]
                   [{:context [(str ns " could not be loaded")]
+                    :error   exception
                     :index   0
                     :ns      ns
                     :file    file

--- a/src/midje_nrepl/reporter.clj
+++ b/src/midje_nrepl/reporter.clj
@@ -136,7 +136,7 @@
   (let [ns (symbol (str ns))]
     (-> no-tests
         (assoc-in [:results ns]
-                  [{:context [(str ns " could not be loaded")]
+                  [{:context [(str ns ": namespace couldn't be loaded")]
                     :error   exception
                     :index   0
                     :ns      ns

--- a/src/midje_nrepl/reporter.clj
+++ b/src/midje_nrepl/reporter.clj
@@ -48,12 +48,12 @@
 
 (defn starting-to-check-fact [fact]
   (let [{:keys [testing-ns file]} @report]
-    (swap! report assoc :current-test {:id         (fact/guid fact)
-                                       :context    (description-for fact)
-                                       :ns         testing-ns
-                                       :file       file
-                                       :line       (fact/line fact)
-                                       :test-forms (pr-str (fact/source fact))})))
+    (swap! report assoc :current-test {:id      (fact/guid fact)
+                                       :context (description-for fact)
+                                       :ns      testing-ns
+                                       :file    file
+                                       :line    (fact/line fact)
+                                       :source  (pr-str (fact/source fact))})))
 
 (defn prettify-expected-and-actual-values [{:keys [expected actual] :as result-map}]
   (let [pretty-str #(with-out-str (pprint/pprint %))]

--- a/src/midje_nrepl/reporter.clj
+++ b/src/midje_nrepl/reporter.clj
@@ -13,8 +13,9 @@
                :summary {:error 0 :fact 0 :fail 0 :ns 0 :pass 0 :skip 0 :test 0}})
 
 (defn reset-report! [{:keys [ns file]}]
+  {:pre [(instance? clojure.lang.Namespace ns) (instance? java.io.File file)]}
   (reset! report
-          (assoc no-tests                :testing-ns ns
+          (assoc no-tests                :testing-ns (symbol (str ns))
                  :file file)))
 
 (defn summarize-test-results! []
@@ -129,7 +130,7 @@
 
 (defmacro with-in-memory-reporter
   [{:keys [ns file] :as context} & forms]
-  `(binding [*ns*                           (the-ns ~ns)
+  `(binding [*ns*                           ~ns
              *file*                         (str ~file)
              midje.config/*config*          (merge midje.config/*config* {:print-level :print-facts})
              midje.state/emission-functions emission-map]

--- a/src/midje_nrepl/test_runner.clj
+++ b/src/midje_nrepl/test_runner.clj
@@ -30,7 +30,7 @@
         (eval `(ns ~namespace))
         (the-ns namespace))))
 
-(defn- evaluate-facts [{:keys [ns source line]}]
+(defn- evaluate-facts [& {:keys [ns source line]}]
   {:pre [(symbol? ns)]}
   (let [the-ns (ensure-ns ns)
         file   (project-info/file-for-ns ns)
@@ -53,14 +53,14 @@
    (run-test namespace source 1))
   ([namespace source line]
    (caching-test-results
-    (evaluate-facts {:ns namespace :source source :line line}))))
+    (evaluate-facts :ns namespace :source source :line line))))
 
 (defn run-tests-in-ns
   "Runs Midje tests in the given namespace.
    Returns the test report."
   [namespace]
   (caching-test-results
-   (evaluate-facts {:ns namespace})))
+   (evaluate-facts :ns namespace)))
 
 (defn- merge-test-reports [reports]
   (reduce (fn [a b]
@@ -73,7 +73,7 @@
     (caching-test-results
      (->> test-paths
           project-info/get-test-namespaces-in
-          (map #(evaluate-facts {:ns %}))
+          (map #(evaluate-facts :ns %))
           merge-test-reports))))
 
 (defn- non-passing-tests [[namespace results]]
@@ -91,5 +91,5 @@
   (caching-test-results
    (->> @test-results
         (keep non-passing-tests)
-        (map #(evaluate-facts {:ns (first %) :source (second %)}))
+        (map #(evaluate-facts :ns (first %) :source (second %)))
         merge-test-reports)))

--- a/src/midje_nrepl/test_runner.clj
+++ b/src/midje_nrepl/test_runner.clj
@@ -33,7 +33,7 @@
 (defn- evaluate-facts [{:keys [ns source line]}]
   {:pre [(symbol? ns)]}
   (let [the-ns (ensure-ns ns)
-        file   (project-info/file-for ns)
+        file   (project-info/file-for-ns ns)
         reader (make-pushback-reader file source line)]
     (with-in-memory-reporter {:ns the-ns :file file}
       (clojure.main/repl
@@ -49,8 +49,8 @@
 
 (defn run-test
   ([namespace source]
-   (run-test namespace 1 source))
-  ([namespace line source]
+   (run-test namespace source 1))
+  ([namespace source line]
    (caching-test-results
     (evaluate-facts {:ns namespace :source source :line line}))))
 
@@ -83,8 +83,8 @@
            (format "(do %s)")
            (list namespace)))))
 
-(defn re-run-failed-tests
-  "Re-runs tests that have failed in the last execution.
+(defn re-run-non-passing-tests
+  "Re-runs tests that didn't pass in the last execution.
   Returns the test report."
   []
   (caching-test-results

--- a/src/midje_nrepl/test_runner.clj
+++ b/src/midje_nrepl/test_runner.clj
@@ -40,7 +40,8 @@
        :read                         #(read reader false %2)
        :need-prompt (constantly false)
        :prompt (fn [])
-       :print  (fn [_])))))
+       :print  (fn [_])
+       :caught #(throw %)))))
 
 (defmacro caching-test-results [& forms]
   `(let [report# ~@forms]

--- a/src/midje_nrepl/test_runner.clj
+++ b/src/midje_nrepl/test_runner.clj
@@ -30,7 +30,7 @@
         (eval `(ns ~namespace))
         (the-ns namespace))))
 
-(defn- evaluate-facts [& {:keys [ns source line]}]
+(defn- check-facts [& {:keys [ns source line]}]
   {:pre [(symbol? ns)]}
   (let [the-ns (ensure-ns ns)
         file   (project-info/file-for-ns ns)
@@ -53,14 +53,14 @@
    (run-test namespace source 1))
   ([namespace source line]
    (caching-test-results
-    (evaluate-facts :ns namespace :source source :line line))))
+    (check-facts :ns namespace :source source :line line))))
 
 (defn run-tests-in-ns
   "Runs Midje tests in the given namespace.
    Returns the test report."
   [namespace]
   (caching-test-results
-   (evaluate-facts :ns namespace)))
+   (check-facts :ns namespace)))
 
 (defn- merge-test-reports [reports]
   (reduce (fn [a b]
@@ -73,7 +73,7 @@
     (caching-test-results
      (->> test-paths
           project-info/get-test-namespaces-in
-          (map #(evaluate-facts :ns %))
+          (map #(check-facts :ns %))
           merge-test-reports))))
 
 (defn- non-passing-tests [[namespace results]]
@@ -91,5 +91,5 @@
   (caching-test-results
    (->> @test-results
         (keep non-passing-tests)
-        (map #(evaluate-facts :ns (first %) :source (second %)))
+        (map #(check-facts :ns (first %) :source (second %)))
         merge-test-reports)))

--- a/test/midje_nrepl/middleware/inhibit_tests_test.clj
+++ b/test/midje_nrepl/middleware/inhibit_tests_test.clj
@@ -72,7 +72,7 @@
                                                            :load-tests? "true"
                                                            :transport   ..transport..} fake-load-ns-handler)
                       => (match {:op          ?op
-                                 :test-report {:summary {:test #(> % 0)}}})
+                                 :test-report {:summary {:check #(> % 0)}}})
                       (provided
                        (transport/send ..transport.. anything) => irrelevant))
                 ?op

--- a/test/midje_nrepl/middleware/inhibit_tests_test.clj
+++ b/test/midje_nrepl/middleware/inhibit_tests_test.clj
@@ -5,7 +5,8 @@
             [matcher-combinators.midje :refer [match]]
             [midje-nrepl.middleware.inhibit-tests :as inhibit-tests]
             [midje-nrepl.reporter :as reporter :refer [with-in-memory-reporter]]
-            [midje.sweet :refer :all]))
+            [midje.sweet :refer :all]
+            [clojure.java.io :as io]))
 
 (def eval-message {:op      "eval"
                    :code    "(+ 1 2)"
@@ -45,7 +46,8 @@
 
 (defn fake-load-ns-handler [{:keys [transport] :as message}]
   (assoc message
-         :test-report (with-in-memory-reporter 'octocat.arithmetic-test
+         :test-report (with-in-memory-reporter {:ns 'octocat.arithmetic-test
+                                                :file (io/file "/home/johndoe/dev/octocat/test/octocat/arithmetic_test.clj")}
                         (require 'octocat.arithmetic-test :reload)
                         (transport/send transport (response-for message :status :done)))))
 

--- a/test/midje_nrepl/middleware/inhibit_tests_test.clj
+++ b/test/midje_nrepl/middleware/inhibit_tests_test.clj
@@ -1,12 +1,13 @@
 (ns midje-nrepl.middleware.inhibit-tests-test
-  (:require [clojure.test :refer [*load-tests*]]
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [*load-tests*]]
             [clojure.tools.nrepl.misc :refer [response-for]]
             [clojure.tools.nrepl.transport :as transport]
             [matcher-combinators.midje :refer [match]]
             [midje-nrepl.middleware.inhibit-tests :as inhibit-tests]
             [midje-nrepl.reporter :as reporter :refer [with-in-memory-reporter]]
-            [midje.sweet :refer :all]
-            [clojure.java.io :as io]))
+            [midje.emission.api :refer [silently]]
+            [midje.sweet :refer :all]))
 
 (def eval-message {:op      "eval"
                    :code    "(+ 1 2)"
@@ -46,12 +47,14 @@
 
 (defn fake-load-ns-handler [{:keys [transport] :as message}]
   (assoc message
-         :test-report (with-in-memory-reporter {:ns 'octocat.arithmetic-test
+         :test-report (with-in-memory-reporter {:ns   (the-ns 'octocat.arithmetic-test)
                                                 :file (io/file "/home/johndoe/dev/octocat/test/octocat/arithmetic_test.clj")}
                         (require 'octocat.arithmetic-test :reload)
                         (transport/send transport (response-for message :status :done)))))
 
 (facts "about loading namespaces without running tests"
+       (against-background
+        (before :contents (silently (require 'octocat.arithmetic-test))))
 
        (tabular (fact "delegates to the base handler without running tests"
                       (inhibit-tests/handle-inhibit-tests {:op ?op :transport ..transport..} fake-load-ns-handler)

--- a/test/midje_nrepl/middleware/test_test.clj
+++ b/test/midje_nrepl/middleware/test_test.clj
@@ -43,12 +43,13 @@
               (transport/send ..transport.. (match {:status #{:done}})) => irrelevant))
 
        (fact "runs the given test and sends the report to the client"
-             (test/handle-test {:op         "midje-test"
-                                :ns         "octocat.arithmetic-test"
-                                :test-forms "(fact (+ 2 3) => 6)"
-                                :transport  ..transport..}) => irrelevant
+             (test/handle-test {:op        "midje-test"
+                                :ns        "octocat.arithmetic-test"
+                                :line 10
+                                :source    "(fact (+ 2 3) => 6)"
+                                :transport ..transport..}) => irrelevant
              (provided
-              (test-runner/run-test 'octocat.arithmetic-test "(fact (+ 2 3) => 6)") => test-report
+              (test-runner/run-test 'octocat.arithmetic-test 10 "(fact (+ 2 3) => 6)") => test-report
               (transport/send ..transport.. transformed-report) => irrelevant
               (transport/send ..transport.. (match {:status #{:done}})) => irrelevant))
 

--- a/test/midje_nrepl/middleware/test_test.clj
+++ b/test/midje_nrepl/middleware/test_test.clj
@@ -45,11 +45,11 @@
        (fact "runs the given test and sends the report to the client"
              (test/handle-test {:op        "midje-test"
                                 :ns        "octocat.arithmetic-test"
-                                :line 10
+                                :line      10
                                 :source    "(fact (+ 2 3) => 6)"
                                 :transport ..transport..}) => irrelevant
              (provided
-              (test-runner/run-test 'octocat.arithmetic-test 10 "(fact (+ 2 3) => 6)") => test-report
+              (test-runner/run-test 'octocat.arithmetic-test "(fact (+ 2 3) => 6)" 10) => test-report
               (transport/send ..transport.. transformed-report) => irrelevant
               (transport/send ..transport.. (match {:status #{:done}})) => irrelevant))
 
@@ -57,7 +57,7 @@
              (test/handle-test {:op        "midje-retest"
                                 :transport ..transport..}) => irrelevant
              (provided
-              (test-runner/re-run-failed-tests) => test-report
+              (test-runner/re-run-non-passing-tests) => test-report
               (transport/send ..transport.. transformed-report) => irrelevant
               (transport/send ..transport.. (match {:status #{:done}})) => irrelevant))
 

--- a/test/midje_nrepl/middleware/test_test.clj
+++ b/test/midje_nrepl/middleware/test_test.clj
@@ -17,7 +17,7 @@
                      :actual   5
                      :message  '()
                      :type     :fail}]}
-                  :summary {:error 0 :fact 1 :fail 1 :ns 1 :pass 0 :skip 0 :test 1}})
+                  :summary {:check 1 :error 0 :fact 1 :fail 1 :ns 1 :pass 0 :to-do 0}})
 
 (def transformed-report (misc/transform-value test-report))
 

--- a/test/midje_nrepl/project_info_test.clj
+++ b/test/midje_nrepl/project_info_test.clj
@@ -23,16 +23,20 @@
                 "amazonica"   false
                 "bouncycastle"   false)
 
+       (fact "returns a java.io.File representing the file where the namespace in question is declared"
+             (.getPath (project-info/file-for 'octocat.arithmetic-test))
+             => #"test/octocat/arithmetic_test.clj$")
+
        (fact "reads the project.clj file of the current project and returns its contents as a list"
              (project-info/read-leiningen-project)
              => (match (m/prefix (list 'defproject 'midje-nrepl string?))))
 
        (fact "reads the project.clj file of the current project and returns it as a map"
              (project-info/read-project-map)
-             => (match {:name 'octocat
-                        :version "1.0.0"
-                        :dependencies         [['org.clojure/clojure "1.9.0"]]
-                        :test-paths           ["test" "src/test/clojure"]})
+             => (match {:name         'octocat
+                        :version      "1.0.0"
+                        :dependencies [['org.clojure/clojure "1.9.0"]]
+                        :test-paths   ["test" "src/test/clojure"]})
              (provided
               (project-info/read-leiningen-project) => lein-project-with-test-paths))
 

--- a/test/midje_nrepl/project_info_test.clj
+++ b/test/midje_nrepl/project_info_test.clj
@@ -24,7 +24,7 @@
                 "bouncycastle"   false)
 
        (fact "returns a java.io.File representing the file where the namespace in question is declared"
-             (.getPath (project-info/file-for 'octocat.arithmetic-test))
+             (.getPath (project-info/file-for-ns 'octocat.arithmetic-test))
              => #"test/octocat/arithmetic_test.clj$")
 
        (fact "reads the project.clj file of the current project and returns its contents as a list"

--- a/test/midje_nrepl/reporter_test.clj
+++ b/test/midje_nrepl/reporter_test.clj
@@ -78,17 +78,17 @@
                                      :position ["arithmetic_test.clj" 15]
                                      :type     :some-prerequisites-were-called-the-wrong-number-of-times})
 
-(def arithmetic-test (io/file "/home/john-doe/dev/octocat/test/octocat/arithmetic_test.clj"))
+(def arithmetic-test-file (io/file "/home/john-doe/dev/octocat/test/octocat/arithmetic_test.clj"))
 
-(def expected-file? #(= % arithmetic-test))
+(def expected-file? #(= % arithmetic-test-file))
 
 (facts "about the midje-nrepl's reporter"
        (against-background
         (before :contents (silently (require 'octocat.arithmetic-test))))
 
        (fact "resets the report atom"
-             (reporter/reset-report! {:ns   'octocat.arithmetic-test
-                                      :file arithmetic-test})
+             (reporter/reset-report! {:ns   (the-ns 'octocat.arithmetic-test)
+                                      :file arithmetic-test-file})
              @reporter/report => (match (m/equals {:testing-ns 'octocat.arithmetic-test
                                                    :file       expected-file?
                                                    :results    {}
@@ -251,7 +251,7 @@ it is interpreted as an error in the test report"
                 failure-with-prerequisit-error  {:message '("These calls were not made the right number of times:" "    (an-impure-function {:first-name \"John\", :last-name \"Doe\"}) [expected at least once, actually never called]")})
 
        (fact "the macro below evaluates the forms with the reporter in context"
-             (reporter/with-in-memory-reporter {:ns 'midje-nrepl.reporter-test :file arithmetic-test}
+             (reporter/with-in-memory-reporter {:ns *ns* :file (io/file *file*)}
                (fact "I'm pretty sure about that"
                      1 => 1))
 
@@ -259,6 +259,6 @@ it is interpreted as an error in the test report"
                                          {'midje-nrepl.reporter-test [{:context ["I'm pretty sure about that"]
                                                                        :index   0
                                                                        :ns      'midje-nrepl.reporter-test
-                                                                       :file    expected-file?
+                                                                       :file    #(= (str %) *file*)
                                                                        :line    number?}]}
                                          :summary {:error 0 :fail 0 :ns 1 :pass 1 :test 1 :skip 0}})))

--- a/test/midje_nrepl/reporter_test.clj
+++ b/test/midje_nrepl/reporter_test.clj
@@ -267,7 +267,7 @@ it is interpreted as an error in the test report"
                (eval '(boom!)))
              => (match {:results
                         {'midje-nrepl.reporter-test
-                         [{:context ["midje-nrepl.reporter-test could not be loaded"]
+                         [{:context ["midje-nrepl.reporter-test: namespace couldn't be loaded"]
                            :error   #(instance? RuntimeException %)
                            :index   0
                            :ns      'midje-nrepl.reporter-test

--- a/test/midje_nrepl/reporter_test.clj
+++ b/test/midje_nrepl/reporter_test.clj
@@ -87,10 +87,10 @@
         (before :contents (silently (require 'octocat.arithmetic-test))))
 
        (fact "resets the report atom"
-             (reporter/reset-report! {:ns 'octocat.arithmetic-test
+             (reporter/reset-report! {:ns   'octocat.arithmetic-test
                                       :file arithmetic-test})
              @reporter/report => (match (m/equals {:testing-ns 'octocat.arithmetic-test
-                                                   :file expected-file?
+                                                   :file       expected-file?
                                                    :results    {}
                                                    :summary    {:error 0 :fact 0 :fail 0 :ns 0 :pass 0 :skip 0 :test 0}})))
 
@@ -103,23 +103,23 @@ it stores its description in the report atom"
 it stores the information about this fact in the report map"
              (reporter/starting-to-check-fact correct-fact-function)
              @reporter/report => (match {:current-test
-                                         {:context    ["this is inquestionable"]
-                                          :ns         'octocat.arithmetic-test
-                                          :file expected-file?
-                                          :line       10
-                                          :test-forms "(fact \"this is inquestionable\" 1 => 1)"}}))
+                                         {:context ["this is inquestionable"]
+                                          :ns      'octocat.arithmetic-test
+                                          :file    expected-file?
+                                          :line    10
+                                          :source  "(fact \"this is inquestionable\" 1 => 1)"}}))
 
        (fact "when the test passes,
 it stores the corresponding test result in the report atom"
              (reporter/pass)
              @reporter/report => (match {:results {'octocat.arithmetic-test
-                                                   [{:context    ["this is inquestionable"]
-                                                     :index      0
-                                                     :ns         'octocat.arithmetic-test
-                                                     :file expected-file?
-                                                     :line       10
-                                                     :test-forms "(fact \"this is inquestionable\" 1 => 1)"
-                                                     :type       :pass}]}}))
+                                                   [{:context ["this is inquestionable"]
+                                                     :index   0
+                                                     :ns      'octocat.arithmetic-test
+                                                     :file    expected-file?
+                                                     :line    10
+                                                     :source  "(fact \"this is inquestionable\" 1 => 1)"
+                                                     :type    :pass}]}}))
 
        (fact "when Midje finishes a top-level fact,
 it dissoc's some keys from the report atom"
@@ -132,23 +132,23 @@ it stores the corresponding test result in the report atom"
              (reporter/starting-to-check-fact wrong-fact-function)
              (reporter/fail failure-with-simple-mismatch)
              @reporter/report => (match {:results {'octocat.arithmetic-test
-                                                   [{:context    ["this is inquestionable"]
-                                                     :index      0
-                                                     :ns         'octocat.arithmetic-test
-                                                     :file expected-file?
-                                                     :line       10
-                                                     :test-forms "(fact \"this is inquestionable\" 1 => 1)"
-                                                     :type       :pass}
-                                                    {:context    ["this is wrong"]
-                                                     :index      1
-                                                     :ns         'octocat.arithmetic-test
-                                                     :file expected-file?
-                                                     :line       15
-                                                     :test-forms "(fact \"this is wrong\" 1 => 2)"
-                                                     :expected   "2\n"
-                                                     :actual     "1\n"
-                                                     :message    '()
-                                                     :type       :fail}]}})
+                                                   [{:context ["this is inquestionable"]
+                                                     :index   0
+                                                     :ns      'octocat.arithmetic-test
+                                                     :file    expected-file?
+                                                     :line    10
+                                                     :source  "(fact \"this is inquestionable\" 1 => 1)"
+                                                     :type    :pass}
+                                                    {:context  ["this is wrong"]
+                                                     :index    1
+                                                     :ns       'octocat.arithmetic-test
+                                                     :file     expected-file?
+                                                     :line     15
+                                                     :source   "(fact \"this is wrong\" 1 => 2)"
+                                                     :expected "2\n"
+                                                     :actual   "1\n"
+                                                     :message  '()
+                                                     :type     :fail}]}})
              (reporter/finishing-top-level-fact wrong-fact-function))
 
        (fact "when the test throws an unexpected exception,
@@ -157,63 +157,63 @@ it is interpreted as an error in the test report"
              (reporter/starting-to-check-fact impossible-fact-function)
              (reporter/fail failure-with-unexpected-exception)
              @reporter/report => (match {:results {'octocat.arithmetic-test
-                                                   [{:context    ["this is inquestionable"]
-                                                     :index      0
-                                                     :ns         'octocat.arithmetic-test
-                                                     :file expected-file?
-                                                     :line       10
-                                                     :test-forms "(fact \"this is inquestionable\" 1 => 1)"
-                                                     :type       :pass}
-                                                    {:context    ["this is wrong"]
-                                                     :index      1
-                                                     :ns         'octocat.arithmetic-test
-                                                     :file expected-file?
-                                                     :line       15
-                                                     :test-forms "(fact \"this is wrong\" 1 => 2)"
-                                                     :expected   "2\n"
-                                                     :actual     "1\n"
-                                                     :message    '()
-                                                     :type       :fail}
-                                                    {:context    ["this is impossible"]
-                                                     :index      2
-                                                     :ns         'octocat.arithmetic-test
-                                                     :file       expected-file?
-                                                     :line       20
-                                                     :test-forms "(fact \"this is impossible\" (/ 10 0) => 0)"
-                                                     :expected   "0\n"
-                                                     :error      #(= arithmetic-exception %)
-                                                     :type       :error}]}})
+                                                   [{:context ["this is inquestionable"]
+                                                     :index   0
+                                                     :ns      'octocat.arithmetic-test
+                                                     :file    expected-file?
+                                                     :line    10
+                                                     :source  "(fact \"this is inquestionable\" 1 => 1)"
+                                                     :type    :pass}
+                                                    {:context  ["this is wrong"]
+                                                     :index    1
+                                                     :ns       'octocat.arithmetic-test
+                                                     :file     expected-file?
+                                                     :line     15
+                                                     :source   "(fact \"this is wrong\" 1 => 2)"
+                                                     :expected "2\n"
+                                                     :actual   "1\n"
+                                                     :message  '()
+                                                     :type     :fail}
+                                                    {:context  ["this is impossible"]
+                                                     :index    2
+                                                     :ns       'octocat.arithmetic-test
+                                                     :file     expected-file?
+                                                     :line     20
+                                                     :source   "(fact \"this is impossible\" (/ 10 0) => 0)"
+                                                     :expected "0\n"
+                                                     :error    #(= arithmetic-exception %)
+                                                     :type     :error}]}})
              (reporter/finishing-top-level-fact impossible-fact-function))
 
        (fact "future facts are interpreted as skipped tests in the report"
              (reporter/future-fact ["TODO"] ["arithmetic_test.clj" 25])
              @reporter/report => (match {:results {'octocat.arithmetic-test
-                                                   [{:context    ["this is inquestionable"]
-                                                     :index      0
-                                                     :ns         'octocat.arithmetic-test
-                                                     :file       expected-file?
-                                                     :line       10
-                                                     :test-forms "(fact \"this is inquestionable\" 1 => 1)"
-                                                     :type       :pass}
-                                                    {:context    ["this is wrong"]
-                                                     :index      1
-                                                     :ns         'octocat.arithmetic-test
-                                                     :file       expected-file?
-                                                     :line       15
-                                                     :test-forms "(fact \"this is wrong\" 1 => 2)"
-                                                     :expected   "2\n"
-                                                     :actual     "1\n"
-                                                     :message    '()
-                                                     :type       :fail}
-                                                    {:context    ["this is impossible"]
-                                                     :index      2
-                                                     :ns         'octocat.arithmetic-test
-                                                     :file       expected-file?
-                                                     :line       20
-                                                     :test-forms "(fact \"this is impossible\" (/ 10 0) => 0)"
-                                                     :expected   "0\n"
-                                                     :error      #(= arithmetic-exception %)
-                                                     :type       :error}
+                                                   [{:context ["this is inquestionable"]
+                                                     :index   0
+                                                     :ns      'octocat.arithmetic-test
+                                                     :file    expected-file?
+                                                     :line    10
+                                                     :source  "(fact \"this is inquestionable\" 1 => 1)"
+                                                     :type    :pass}
+                                                    {:context  ["this is wrong"]
+                                                     :index    1
+                                                     :ns       'octocat.arithmetic-test
+                                                     :file     expected-file?
+                                                     :line     15
+                                                     :source   "(fact \"this is wrong\" 1 => 2)"
+                                                     :expected "2\n"
+                                                     :actual   "1\n"
+                                                     :message  '()
+                                                     :type     :fail}
+                                                    {:context  ["this is impossible"]
+                                                     :index    2
+                                                     :ns       'octocat.arithmetic-test
+                                                     :file     expected-file?
+                                                     :line     20
+                                                     :source   "(fact \"this is impossible\" (/ 10 0) => 0)"
+                                                     :expected "0\n"
+                                                     :error    #(= arithmetic-exception %)
+                                                     :type     :error}
                                                     {:context ["TODO"]
                                                      :index   3
                                                      :line    25

--- a/test/midje_nrepl/reporter_test.clj
+++ b/test/midje_nrepl/reporter_test.clj
@@ -268,6 +268,7 @@ it is interpreted as an error in the test report"
              => (match {:results
                         {'midje-nrepl.reporter-test
                          [{:context ["midje-nrepl.reporter-test could not be loaded"]
+                           :error   #(instance? RuntimeException %)
                            :index   0
                            :ns      'midje-nrepl.reporter-test
                            :file    #(= (str %) *file*)

--- a/test/midje_nrepl/reporter_test.clj
+++ b/test/midje_nrepl/reporter_test.clj
@@ -87,12 +87,11 @@
         (before :contents (silently (require 'octocat.arithmetic-test))))
 
        (fact "resets the report atom"
-             (reporter/reset-report! {:ns   (the-ns 'octocat.arithmetic-test)
-                                      :file arithmetic-test-file})
+             (reporter/reset-report! (the-ns 'octocat.arithmetic-test) arithmetic-test-file)
              @reporter/report => (match (m/equals {:testing-ns 'octocat.arithmetic-test
                                                    :file       expected-file?
                                                    :results    {}
-                                                   :summary    {:error 0 :fact 0 :fail 0 :ns 0 :pass 0 :skip 0 :test 0}})))
+                                                   :summary    {:check 0 :error 0 :fact 0 :fail 0 :ns 0 :pass 0 :to-do 0}})))
 
        (fact "when Midje starts checking a top level fact,
 it stores its description in the report atom"
@@ -185,7 +184,7 @@ it is interpreted as an error in the test report"
                                                      :type     :error}]}})
              (reporter/finishing-top-level-fact impossible-fact-function))
 
-       (fact "future facts are interpreted as skipped tests in the report"
+       (fact "future facts are interpreted as work to do in the report"
              (reporter/future-fact ["TODO"] ["arithmetic_test.clj" 25])
              @reporter/report => (match {:results {'octocat.arithmetic-test
                                                    [{:context ["this is inquestionable"]
@@ -217,17 +216,17 @@ it is interpreted as an error in the test report"
                                                     {:context ["TODO"]
                                                      :index   3
                                                      :line    25
-                                                     :type    :skip}]}}))
+                                                     :type    :to-do}]}}))
 
        (fact "summarizes test results, by computing the counters for each category"
              (reporter/summarize-test-results!)
-             @reporter/report => (match {:summary {:error 1
+             @reporter/report => (match {:summary {:check 4
+                                                   :error 1
                                                    :fact  3
                                                    :fail  1
                                                    :ns    1
                                                    :pass  1
-                                                   :skip  1
-                                                   :test  4}}))
+                                                   :to-do 1}}))
 
        (fact "drops irrelevant keys from the report map"
              (keys @reporter/report) => (match (m/in-any-order [:results :summary :testing-ns :file]))
@@ -261,7 +260,7 @@ it is interpreted as an error in the test report"
                                                                        :ns      'midje-nrepl.reporter-test
                                                                        :file    #(= (str %) *file*)
                                                                        :line    number?}]}
-                                         :summary {:error 0 :fail 0 :ns 1 :pass 1 :test 1 :skip 0}}))
+                                         :summary {:check 1 :error 0 :fail 0 :ns 1 :pass 1 :to-do 0}}))
 
        (fact "catches any compilation error raised inside the macro body and returns it as an error in the report map"
              (reporter/with-in-memory-reporter {:ns *ns* :file (io/file *file*)}
@@ -274,4 +273,4 @@ it is interpreted as an error in the test report"
                            :file    #(= (str %) *file*)
                            :line    number?
                            :type    :error}]}
-                        :summary {:error 1 :fail 0 :ns 1 :pass 0 :test 0 :skip 0}})))
+                        :summary {:check 0 :error 1 :fail 0 :ns 1 :pass 0 :to-do 0}})))

--- a/test/midje_nrepl/reporter_test.clj
+++ b/test/midje_nrepl/reporter_test.clj
@@ -261,4 +261,17 @@ it is interpreted as an error in the test report"
                                                                        :ns      'midje-nrepl.reporter-test
                                                                        :file    #(= (str %) *file*)
                                                                        :line    number?}]}
-                                         :summary {:error 0 :fail 0 :ns 1 :pass 1 :test 1 :skip 0}})))
+                                         :summary {:error 0 :fail 0 :ns 1 :pass 1 :test 1 :skip 0}}))
+
+       (fact "catches any compilation error raised inside the macro body and returns it as an error in the report map"
+             (reporter/with-in-memory-reporter {:ns *ns* :file (io/file *file*)}
+               (eval '(boom!)))
+             => (match {:results
+                        {'midje-nrepl.reporter-test
+                         [{:context ["midje-nrepl.reporter-test could not be loaded"]
+                           :index   0
+                           :ns      'midje-nrepl.reporter-test
+                           :file    #(= (str %) *file*)
+                           :line    number?
+                           :type    :error}]}
+                        :summary {:error 1 :fail 0 :ns 1 :pass 0 :test 0 :skip 0}})))

--- a/test/midje_nrepl/test_runner_test.clj
+++ b/test/midje_nrepl/test_runner_test.clj
@@ -9,8 +9,8 @@
          (.exists candidate)))
 
 (def individual-test-report {:results
-                             {'midje-nrepl.test-runner-test
-                              [{:ns      'midje-nrepl.test-runner-test
+                             {'octocat.arithmetic-test
+                              [{:ns      'octocat.arithmetic-test
                                 :file    existing-file?
                                 :context ["(fact 1 => 1)"]
                                 :index   0
@@ -160,39 +160,14 @@
                               (partial format "(with-isolated-output-counters %s)")))
                 vec))))
 
-(facts "about running individual tests"
-
-       (fact "runs the test source passed as a string"
-             (test-runner/run-test 'midje-nrepl.test-runner-test "(with-isolated-output-counters (fact 1 => 1))")
-             => (match individual-test-report))
-
-       (fact "line numbers are resolved correctly for individual facts, taking the supplied starting line in consideration"
-             (test-runner/run-test 'midje-nrepl.test-runner-test 10 "(with-isolated-output-counters
-(fact \"this is wrong\"
-1 => 2))")
-             => (match {:results {'midje-nrepl.test-runner-test
-                                  [{:type :fail
-                                    :line 12}]}}))
-
-       (fact "returns a report with no tests when there are no tests to be run"
-             (test-runner/run-test 'midje-nrepl.test-runner-test "(fact)")
-             => (match {:results {}
-                        :summary {:ns 0 :test 0}}))
-
-       (fact "results of the last execution are kept in the current session"
-             (test-runner/run-test 'midje-nrepl.test-runner-test "(with-isolated-output-counters (fact 1 => 1))")
-             => (match individual-test-report)
-             @test-runner/test-results
-             => (match (:results individual-test-report))))
-
 (facts "about running tests in a given namespace"
 
        (tabular (fact "runs all tests in the given namespace"
                       (test-runner/run-tests-in-ns ?namespace) => (match ?report))
-                ?namespace ?report
+                ?namespace                ?report
                 'octocat.arithmetic-test arithmetic-test-report
-                'octocat.colls-test colls-test-report
-                'octocat.mocks-test mocks-test-report)
+                'octocat.colls-test      colls-test-report
+                'octocat.mocks-test      mocks-test-report)
 
        (fact "returns a report with no tests when there are no tests to be run"
              (test-runner/run-tests-in-ns 'octocat.no-tests)
@@ -203,6 +178,31 @@
              (test-runner/run-tests-in-ns 'octocat.arithmetic-test) => (match arithmetic-test-report)
              @test-runner/test-results
              => (match (:results arithmetic-test-report))))
+
+(facts "about running individual tests"
+
+       (fact "runs the test source passed as a string"
+             (test-runner/run-test 'octocat.arithmetic-test "(with-isolated-output-counters (fact 1 => 1))")
+             => (match individual-test-report))
+
+       (fact "line numbers are resolved correctly for individual facts, taking the supplied starting line in consideration"
+             (test-runner/run-test 'octocat.arithmetic-test 10 "(with-isolated-output-counters
+(fact \"this is wrong\"
+1 => 2))")
+             => (match {:results {'octocat.arithmetic-test
+                                  [{:type :fail
+                                    :line 12}]}}))
+
+       (fact "returns a report with no tests when there are no tests to be run"
+             (test-runner/run-test 'octocat.arithmetic-test "(fact)")
+             => (match {:results {}
+                        :summary {:ns 0 :test 0}}))
+
+       (fact "results of the last execution are kept in the current session"
+             (test-runner/run-test 'octocat.arithmetic-test "(with-isolated-output-counters (fact 1 => 1))")
+             => (match individual-test-report)
+             @test-runner/test-results
+             => (match (:results individual-test-report))))
 
 (facts "about running all tests in the project"
        (against-background
@@ -233,7 +233,7 @@
              (test-runner/re-run-failed-tests) => (match re-run-arithmetic-test-report))
 
        (fact "returns a report with no tests when there are no failing or erring tests to be run"
-             (test-runner/run-test 'midje-nrepl.test-runner-test "(with-isolated-output-counters (fact (+ 1 2) => 3))")
+             (test-runner/run-test 'octocat.arithmetic-test "(with-isolated-output-counters (fact (+ 1 2) => 3))")
              => (match {:summary {:error 0 :fail 0 :ns 1 :pass 1 :test 1}})
              (test-runner/re-run-failed-tests)
              => (match {:results {}

--- a/test/midje_nrepl/test_runner_test.clj
+++ b/test/midje_nrepl/test_runner_test.clj
@@ -186,9 +186,9 @@
              => (match individual-test-report))
 
        (fact "line numbers are resolved correctly for individual facts, taking the supplied starting line in consideration"
-             (test-runner/run-test 'octocat.arithmetic-test 10 "(with-isolated-output-counters
+             (test-runner/run-test 'octocat.arithmetic-test "(with-isolated-output-counters
 (fact \"this is wrong\"
-1 => 2))")
+1 => 2))" 10)
              => (match {:results {'octocat.arithmetic-test
                                   [{:type :fail
                                     :line 12}]}}))
@@ -230,28 +230,28 @@
        (fact "re-runs tests that didn't pass in the last execution"
              (test-runner/run-tests-in-ns 'octocat.arithmetic-test) => (match arithmetic-test-report)
              (isolate-test-forms! 'octocat.arithmetic-test)
-             (test-runner/re-run-failed-tests) => (match re-run-arithmetic-test-report))
+             (test-runner/re-run-non-passing-tests) => (match re-run-arithmetic-test-report))
 
        (fact "returns a report with no tests when there are no failing or erring tests to be run"
              (test-runner/run-test 'octocat.arithmetic-test "(with-isolated-output-counters (fact (+ 1 2) => 3))")
              => (match {:summary {:error 0 :fail 0 :ns 1 :pass 1 :test 1}})
-             (test-runner/re-run-failed-tests)
+             (test-runner/re-run-non-passing-tests)
              => (match {:results {}
                         :summary {:ns 0 :test 0}}))
 
        (fact "results of the last execution are kept in the current session as well"
              (test-runner/run-tests-in-ns 'octocat.arithmetic-test) => (match arithmetic-test-report)
              (isolate-test-forms! 'octocat.arithmetic-test)
-             (test-runner/re-run-failed-tests) => (match re-run-arithmetic-test-report)
+             (test-runner/re-run-non-passing-tests) => (match re-run-arithmetic-test-report)
              @test-runner/test-results
              => (match (:results re-run-arithmetic-test-report)))
 
        (fact "by re-running the same tests twice, the same results are obtained"
              (test-runner/run-tests-in-ns 'octocat.arithmetic-test) => (match arithmetic-test-report)
              (isolate-test-forms! 'octocat.arithmetic-test)
-             (test-runner/re-run-failed-tests) => (match re-run-arithmetic-test-report)
+             (test-runner/re-run-non-passing-tests) => (match re-run-arithmetic-test-report)
              (isolate-test-forms! 'octocat.arithmetic-test)
-             (test-runner/re-run-failed-tests) => (match re-run-arithmetic-test-report)))
+             (test-runner/re-run-non-passing-tests) => (match re-run-arithmetic-test-report)))
 
 (facts "about getting test stacktraces"
 

--- a/test/midje_nrepl/test_runner_test.clj
+++ b/test/midje_nrepl/test_runner_test.clj
@@ -2,9 +2,7 @@
   (:require [matcher-combinators.midje :refer [match]]
             [midje-nrepl.project-info :as project-info]
             [midje-nrepl.test-runner :as test-runner]
-            [midje.emission.state :refer [with-isolated-output-counters]]
-            [midje.sweet :refer :all]
-            [matcher-combinators.matchers :as m]))
+            [midje.sweet :refer :all]))
 
 (defn existing-file? [candidate]
   (and   (instance? java.io.File candidate)
@@ -12,12 +10,12 @@
 
 (def individual-test-report {:results
                              {'midje-nrepl.test-runner-test
-                              [{:ns         'midje-nrepl.test-runner-test
-                                :file       existing-file?
-                                :context    ["(fact 1 => 1)"]
-                                :index      0
-                                :source "(fact 1 => 1)"
-                                :type       :pass}]}
+                              [{:ns      'midje-nrepl.test-runner-test
+                                :file    existing-file?
+                                :context ["(fact 1 => 1)"]
+                                :index   0
+                                :source  "(fact 1 => 1)"
+                                :type    :pass}]}
                              :summary {:ns 1 :fact 1 :fail 0 :error 0 :pass 1 :test 1 :skip 0}})
 
 (def arithmetic-test-report {:results
@@ -61,36 +59,36 @@
 
 (def re-run-arithmetic-test-report {:results
                                     {'octocat.arithmetic-test
-                                     (m/in-any-order [{:context  ["this is a crazy arithmetic"]
-                                                       :index    0
-                                                       :ns       'octocat.arithmetic-test
-                                                       :file     existing-file?
-                                                       :expected "6\n"
-                                                       :actual   "5\n"
-                                                       :message  '()
-                                                       :type     :fail}
-                                                      {:context
-                                                       ["two assertions in the same fact; the former is correct while the later is wrong"]
-                                                       :index 1
-                                                       :ns    'octocat.arithmetic-test
-                                                       :file  existing-file?
-                                                       :type  :pass}
-                                                      {:context
-                                                       ["two assertions in the same fact; the former is correct while the later is wrong"]
-                                                       :index    2
-                                                       :ns       'octocat.arithmetic-test
-                                                       :file     existing-file?
-                                                       :expected "3\n"
-                                                       :actual   "2\n"
-                                                       :message  '()
-                                                       :type     :fail}
-                                                      {:context  ["this will throw an unexpected exception"]
-                                                       :index    3
-                                                       :ns       'octocat.arithmetic-test
-                                                       :file     existing-file?
-                                                       :expected "0\n"
-                                                       :error    #(instance? ArithmeticException %)
-                                                       :type     :error}])}
+                                     [{:context  ["this is a crazy arithmetic"]
+                                       :index    0
+                                       :ns       'octocat.arithmetic-test
+                                       :file     existing-file?
+                                       :expected "6\n"
+                                       :actual   "5\n"
+                                       :message  '()
+                                       :type     :fail}
+                                      {:context
+                                       ["two assertions in the same fact; the former is correct while the later is wrong"]
+                                       :index 1
+                                       :ns    'octocat.arithmetic-test
+                                       :file  existing-file?
+                                       :type  :pass}
+                                      {:context
+                                       ["two assertions in the same fact; the former is correct while the later is wrong"]
+                                       :index    2
+                                       :ns       'octocat.arithmetic-test
+                                       :file     existing-file?
+                                       :expected "3\n"
+                                       :actual   "2\n"
+                                       :message  '()
+                                       :type     :fail}
+                                      {:context  ["this will throw an unexpected exception"]
+                                       :index    3
+                                       :ns       'octocat.arithmetic-test
+                                       :file     existing-file?
+                                       :expected "0\n"
+                                       :error    #(instance? ArithmeticException %)
+                                       :type     :error}]}
                                     :summary {:error 1 :fact 3 :fail 2 :ns 1 :pass 1 :skip 0 :test 4}})
 
 (def colls-test-report {:results
@@ -165,7 +163,7 @@
 (facts "about running individual tests"
 
        (fact "runs the test source passed as a string"
-             (test-runner/run-test 'midje-nrepl.test-runner-test 1 "(with-isolated-output-counters (fact 1 => 1))")
+             (test-runner/run-test 'midje-nrepl.test-runner-test "(with-isolated-output-counters (fact 1 => 1))")
              => (match individual-test-report))
 
        (fact "line numbers are resolved correctly for individual facts, taking the supplied starting line in consideration"
@@ -177,12 +175,12 @@
                                     :line 12}]}}))
 
        (fact "returns a report with no tests when there are no tests to be run"
-             (test-runner/run-test 'midje-nrepl.test-runner-test 1 "(fact)")
+             (test-runner/run-test 'midje-nrepl.test-runner-test "(fact)")
              => (match {:results {}
                         :summary {:ns 0 :test 0}}))
 
        (fact "results of the last execution are kept in the current session"
-             (test-runner/run-test 'midje-nrepl.test-runner-test 1 "(with-isolated-output-counters (fact 1 => 1))")
+             (test-runner/run-test 'midje-nrepl.test-runner-test "(with-isolated-output-counters (fact 1 => 1))")
              => (match individual-test-report)
              @test-runner/test-results
              => (match (:results individual-test-report))))
@@ -234,7 +232,7 @@
              (isolate-test-forms! 'octocat.arithmetic-test)
              (test-runner/re-run-failed-tests) => (match re-run-arithmetic-test-report))
 
-       (fact "returns a report with no tests when there are no failed tests to be run"
+       (fact "returns a report with no tests when there are no failing or erring tests to be run"
              (test-runner/run-test 'midje-nrepl.test-runner-test "(with-isolated-output-counters (fact (+ 1 2) => 3))")
              => (match {:summary {:error 0 :fail 0 :ns 1 :pass 1 :test 1}})
              (test-runner/re-run-failed-tests)
@@ -246,7 +244,14 @@
              (isolate-test-forms! 'octocat.arithmetic-test)
              (test-runner/re-run-failed-tests) => (match re-run-arithmetic-test-report)
              @test-runner/test-results
-             => (match (:results re-run-arithmetic-test-report))))
+             => (match (:results re-run-arithmetic-test-report)))
+
+       (fact "by re-running the same tests twice, the same results are obtained"
+             (test-runner/run-tests-in-ns 'octocat.arithmetic-test) => (match arithmetic-test-report)
+             (isolate-test-forms! 'octocat.arithmetic-test)
+             (test-runner/re-run-failed-tests) => (match re-run-arithmetic-test-report)
+             (isolate-test-forms! 'octocat.arithmetic-test)
+             (test-runner/re-run-failed-tests) => (match re-run-arithmetic-test-report)))
 
 (facts "about getting test stacktraces"
 

--- a/test/midje_nrepl/test_runner_test.clj
+++ b/test/midje_nrepl/test_runner_test.clj
@@ -16,7 +16,7 @@
                                 :index   0
                                 :source  "(fact 1 => 1)"
                                 :type    :pass}]}
-                             :summary {:ns 1 :fact 1 :fail 0 :error 0 :pass 1 :test 1 :skip 0}})
+                             :summary {:check 1 :ns 1 :fact 1 :fail 0 :error 0 :pass 1 :to-do 0}})
 
 (def arithmetic-test-report {:results
                              {'octocat.arithmetic-test
@@ -55,7 +55,7 @@
                                 :expected "0\n"
                                 :error    #(instance? ArithmeticException %)
                                 :type     :error}]}
-                             :summary {:error 1 :fact 4 :fail 2 :ns 1 :pass 2 :skip 0 :test 5}})
+                             :summary {:check 5 :error 1 :fact 4 :fail 2 :ns 1 :pass 2 :to-do 0}})
 
 (def re-run-arithmetic-test-report {:results
                                     {'octocat.arithmetic-test
@@ -89,7 +89,7 @@
                                        :expected "0\n"
                                        :error    #(instance? ArithmeticException %)
                                        :type     :error}]}
-                                    :summary {:error 1 :fact 3 :fail 2 :ns 1 :pass 1 :skip 0 :test 4}})
+                                    :summary {:check 4 :error 1 :fact 3 :fail 2 :ns 1 :pass 1 :to-do 0}})
 
 (def colls-test-report {:results
                         {'octocat.colls-test
@@ -121,7 +121,7 @@
                            :expected "(match (m/in-any-order [3 2 4]))\n"
                            :actual   "[1 2 3]\n"
                            :type     :fail}]}
-                        :summary {:error 0 :fact 3 :fail 4 :ns 1 :pass 0 :skip 0 :test 4}})
+                        :summary {:check 4 :error 0 :fact 3 :fail 4 :ns 1 :pass 0 :to-do 0}})
 
 (def mocks-test-report {:results
                         {'octocat.mocks-test
@@ -143,12 +143,12 @@
                            :actual   "\"`an-impure-function` returned this string because it was called with an unexpected argument\"\n"
                            :message  '()
                            :type     :fail}]}
-                        :summary {:error 0 :fact 1 :fail 3 :ns 1 :pass 0 :skip 0 :test 3}})
+                        :summary {:check 3 :error 0 :fact 1 :fail 3 :ns 1 :pass 0 :to-do 0}})
 
 (def all-tests-report {:results (merge (:results arithmetic-test-report)
                                        (:results colls-test-report)
                                        (:results mocks-test-report))
-                       :summary {:error 1 :fact 8 :fail 9 :ns 3 :pass 2 :skip 0 :test 12}})
+                       :summary {:check 12 :error 1 :fact 8 :fail 9 :ns 3 :pass 2 :to-do 0}})
 
 (defn isolate-test-forms!
   "Workaround to test the re-run feature without modifying Midje counters."
@@ -172,7 +172,7 @@
        (fact "returns a report with no tests when there are no tests to be run"
              (test-runner/run-tests-in-ns 'octocat.no-tests)
              => (match {:results {}
-                        :summary {:ns 0 :test 0}}))
+                        :summary {:check 0 :ns 0}}))
 
        (fact "results of the last execution are kept in the current session"
              (test-runner/run-tests-in-ns 'octocat.arithmetic-test) => (match arithmetic-test-report)
@@ -196,7 +196,7 @@
        (fact "returns a report with no tests when there are no tests to be run"
              (test-runner/run-test 'octocat.arithmetic-test "(fact)")
              => (match {:results {}
-                        :summary {:ns 0 :test 0}}))
+                        :summary {:check 0 :ns 0}}))
 
        (fact "results of the last execution are kept in the current session"
              (test-runner/run-test 'octocat.arithmetic-test "(with-isolated-output-counters (fact 1 => 1))")
@@ -215,7 +215,7 @@
        (fact "returns a report with no tests when there are no tests to be run"
              (test-runner/run-all-tests)
              => (match {:results {}
-                        :summary {:ns 0 :test 0}})
+                        :summary {:check 0 :ns 0}})
              (provided
               (project-info/get-test-namespaces-in ["test/octocat"]) => ['octocat.no-tests]))
 
@@ -234,10 +234,10 @@
 
        (fact "returns a report with no tests when there are no failing or erring tests to be run"
              (test-runner/run-test 'octocat.arithmetic-test "(with-isolated-output-counters (fact (+ 1 2) => 3))")
-             => (match {:summary {:error 0 :fail 0 :ns 1 :pass 1 :test 1}})
+             => (match {:summary {:error 0 :fail 0 :ns 1 :pass 1 :check 1}})
              (test-runner/re-run-non-passing-tests)
              => (match {:results {}
-                        :summary {:ns 0 :test 0}}))
+                        :summary {:check 0 :ns 0}}))
 
        (fact "results of the last execution are kept in the current session as well"
              (test-runner/run-tests-in-ns 'octocat.arithmetic-test) => (match arithmetic-test-report)


### PR DESCRIPTION
Enhances the test runner by providing support for returning the correct line number when a in-line test is run. In
addition, as of this pull request, if the test namespace can not be loaded due to a compilation error, midje-nrepl will
return an error in the report map instead of throwing an unhandled exception.