### PR TITLE
Support explicit syntax on tabular formatter

### DIFF
--- a/src/midje_nrepl/formatter.clj
+++ b/src/midje_nrepl/formatter.clj
@@ -53,11 +53,11 @@
   (boolean (re-find #"^\?|^\[\?" value)))
 
 (defn- number-of-columns-fn [cells]
-  (let [expanded-cells (expand-headers-on-cells cells)
+  (let [expanded-cells cells #_(expand-headers-on-cells cells)
         number-of-headers (count (take-while table-header? expanded-cells))]
     (if-not (zero? number-of-headers)
       number-of-headers
-      (throw-exception ::no-table-headers "Table has no headers. Check if headers start with `?``"))))
+      (throw-exception ::no-table-headers "Table has no headers. Check if headers start with `?`"))))
 
 (defn paddings-for-cells [cells options]
   (let [number-of-columns (number-of-columns-fn cells)]

--- a/test/midje_nrepl/formatter_test.clj
+++ b/test/midje_nrepl/formatter_test.clj
@@ -4,21 +4,21 @@
             [midje.sweet :refer :all]))
 
 (tabular (fact "determines the padding left and right to the supplied text according to the alignment option and the width"
-               (formatter/paddings ?text ?alignment ?width)
-               => {:padding-left  ?padding-left
-                   :padding-right ?padding-right})
-         ?text ?alignment ?width ?padding-left ?padding-right
-         "text" :center 4 0 0
-         "text" :center 13 4 5
-         "hello" :center 15 5 5
-         "text" :center 20 8 8
-         "hello" :center 20 7 8
-         "text" :left 4 0 0
-         "text" :left 20 0 16
-         "text" :right 4 0 0
-         "text" :right 20 16 0
-         "hello" :left 11 0 6
-         "hello" :right 15 10 0)
+           (formatter/paddings ?text ?alignment ?width)
+           => {:padding-left  ?padding-left
+               :padding-right ?padding-right})
+  ?text ?alignment ?width ?padding-left ?padding-right
+  "text" :center 4 0 0
+  "text" :center 13 4 5
+  "hello" :center 15 5 5
+  "text" :center 20 8 8
+  "hello" :center 20 7 8
+  "text" :left 4 0 0
+  "text" :left 20 0 16
+  "text" :right 4 0 0
+  "text" :right 20 16 0
+  "hello" :left 11 0 6
+  "hello" :right 15 10 0)
 
 (def table ["?x" "?y" "?result"
             "4" "5" "9"
@@ -41,13 +41,14 @@
                      {:leftmost-cell? true :padding-left 0 :padding-right 0} {:padding-left 0 :padding-right 0} {:rightmost-cell? true :padding-left 1 :padding-right 2}])
 
 (tabular (fact "determines the paddings for the supplied table according to the alignment options"
-               (formatter/paddings-for-cells ?table {:alignment ?alignment}) => ?aligned-table)
-         ?table ?alignment ?aligned-table
-         table :right right-aligned-table
-         table :left left-aligned-table
-         table :center centered-table)
+           (formatter/paddings-for-cells ?table {:alignment ?alignment}) => ?aligned-table)
+  ?table ?alignment ?aligned-table
+  table :right right-aligned-table
+  table :left left-aligned-table
+  table :center centered-table)
 
-(def basic-tabular "(tabular (fact \"about basic arithmetic operations\"
+(def basic-tabular
+  "(tabular (fact \"about basic arithmetic operations\"
   (?operation ?a ?b) => ?result)
   ?operation ?a ?b ?result
   + 2 5 10
@@ -57,7 +58,19 @@
   / 15 8 15/8
   / 4284 126 34)")
 
-(def right-aligned-basic-tabular "(tabular (fact \"about basic arithmetic operations\"
+(def basic-tabular-w-deliniated-header
+  "(tabular (fact \"about basic arithmetic operations\"
+  (?operation ?a ?b) => ?result)
+  [?operation ?a ?b ?result]
+  + 2 5 10
+  + 10 4 14
+  - 100 25 75
+    * 123 69 8487
+  / 15 8 15/8
+  / 4284 126 34)")
+
+(def right-aligned-basic-tabular
+  "(tabular (fact \"about basic arithmetic operations\"
   (?operation ?a ?b) => ?result)
   ?operation   ?a  ?b ?result
            +    2   5      10
@@ -67,18 +80,32 @@
            /   15   8    15/8
            / 4284 126      34)")
 
-(def just-a-fact "(fact \"this isn't a tabular\"
+(def right-aligned-basic-tabular-w-deliniated-header
+  "(tabular (fact \"about basic arithmetic operations\"
+  (?operation ?a ?b) => ?result)
+  [?operation   ?a  ?b ?result]
+            +    2   5      10
+            +   10   4      14
+            -  100  25      75
+            *  123  69    8487
+            /   15   8    15/8
+            / 4284 126      34)")
+
+(def just-a-fact
+  "(fact \"this isn't a tabular\"
   (+ 1 2) => 3)")
 
 (def just-a-vector "[:blue :red :yellow]")
 
-(def tabular-with-no-headers "(tabular (fact \"this is an invalid tabular\"
+(def tabular-with-no-headers
+  "(tabular (fact \"this is an invalid tabular\"
   (inc ?x) => ?y)
   1 2
   20 21
   100 101)")
 
-(def malformed-tabular "(tabular (fact \"this one is malformed\"
+(def malformed-tabular
+  "(tabular (fact \"this one is malformed\"
   (inc ?x) => ?y)
   ?x ?y
   1 2
@@ -89,11 +116,13 @@
   (throws clojure.lang.ExceptionInfo #(matcher-combinators/match? (matcher-combinators/match matcher (ex-data %)))))
 
 (tabular (fact "formats the tabular fact according to default options"
-               (formatter/format-tabular ?tabular)
-               => ?result)
-         ?tabular ?result
-         basic-tabular right-aligned-basic-tabular
-         just-a-fact (throws-match {:type ::formatter/no-tabular})
-         just-a-vector (throws-match {:type ::formatter/no-tabular})
-         tabular-with-no-headers (throws-match {:type ::formatter/no-table-headers})
-         malformed-tabular (throws-match {:type ::formatter/malformed-table}))
+           (formatter/format-tabular ?tabular)
+           => ?result)
+  ?tabular ?result
+  basic-tabular right-aligned-basic-tabular
+  basic-tabular-w-deliniated-header right-aligned-basic-tabular-w-deliniated-header
+  just-a-fact (throws-match {:type ::formatter/no-tabular})
+  just-a-vector (throws-match {:type ::formatter/no-tabular})
+  tabular-with-no-headers (throws-match {:type ::formatter/no-table-headers})
+  malformed-tabular (throws-match {:type ::formatter/malformed-table})
+  )


### PR DESCRIPTION
Midje has a new way to declare tabulars (see it [here](https://github.com/marick/Midje/wiki/Tabular-facts#explicit-syntax)). The tabular formatter should take this in consideration, otherwise it wouldn't work for this case.