### PR TITLE
Solve conflict with org.clojure/tools.namespace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/tools.namespace "0.3.0-alpha4"]
                  [org.clojure/tools.nrepl "0.2.13"]
                  [cider/orchard "0.3.0"]
                  [rewrite-clj "0.6.0"]]

--- a/src/midje_nrepl/misc.clj
+++ b/src/midje_nrepl/misc.clj
@@ -1,0 +1,11 @@
+(ns midje-nrepl.misc
+  (:require             [orchard.classpath :as classpath]))
+
+(defn dependency-in-classpath?
+  "Return true if a given dependency is in the project's classpath, or false otherwise."
+  [^String dep-name]
+  (let [pattern (re-pattern (str "/" dep-name ".*\\.jar$"))]
+    (->> (classpath/classpath)
+         (map #(.getPath %))
+         (some (partial re-find pattern))
+         boolean)))

--- a/src/midje_nrepl/nrepl.clj
+++ b/src/midje_nrepl/nrepl.clj
@@ -5,7 +5,7 @@
             [clojure.tools.nrepl.middleware.interruptible-eval :as eval]
             [clojure.tools.nrepl.misc :refer [response-for]]
             [clojure.tools.nrepl.transport :as transport]
-            [midje-nrepl.project-info :as project-info]))
+            [midje-nrepl.misc :as misc]))
 
 (defn- greatest-arity-of [handler-var]
   {:post [(or (= % 1) (= % 2))]}
@@ -60,7 +60,7 @@
 (defn middleware-vars-expected-by-wrap-inhibit-tests []
   (let [middleware-vars #{#'eval/interruptible-eval
                           #'cider/wrap-refresh}]
-    (if (project-info/dependency-in-classpath? "refactor-nrepl")
+    (if (misc/dependency-in-classpath? "refactor-nrepl")
       (set/union middleware-vars #{(resolve 'refactor-nrepl.middleware/wrap-refactor)})
       middleware-vars)))
 

--- a/src/midje_nrepl/plugin.clj
+++ b/src/midje_nrepl/plugin.clj
@@ -2,9 +2,18 @@
   (:require [midje-nrepl.middleware.version :as version]
             [midje-nrepl.nrepl :as midje-nrepl]))
 
+(def ^:private clojure-tools-namespace ['org.clojure/tools.namespace "0.3.0-alpha4"])
+
+(defn- remove-conflicting-dependencies [dependencies]
+  (remove (fn [[name]]
+            (= name 'org.clojure/tools.namespace))
+          dependencies))
+
 (defn middleware [project]
   (-> project
       (update :dependencies (fnil concat [])
               [['midje-nrepl (version/get-current-version)]])
+      (update :dependencies remove-conflicting-dependencies)
+      (update :dependencies concat [clojure-tools-namespace])
       (update-in [:repl-options :nrepl-middleware]                 (fnil concat [])
                  midje-nrepl/middleware)))

--- a/src/midje_nrepl/project_info.clj
+++ b/src/midje_nrepl/project_info.clj
@@ -1,20 +1,10 @@
 (ns midje-nrepl.project-info
   (:require [clojure.java.io :as io]
             [clojure.tools.namespace.find :as namespace.find]
-            [orchard.classpath :as classpath]
             [orchard.namespace :as namespace])
   (:import [java.io FileReader PushbackReader]))
 
 (def ^:private leiningen-project-file "project.clj")
-
-(defn dependency-in-classpath?
-  "Returns true if a given dependency is in the project's classpath, or false otherwise."
-  [^String dep-name]
-  (let [pattern (re-pattern (str "/" dep-name ".*\\.jar$"))]
-    (->> (classpath/classpath)
-         (map #(.getPath %))
-         (some (partial re-find pattern))
-         boolean)))
 
 (defn file-for-ns [namespace]
   (some-> (name namespace)

--- a/test/midje_nrepl/misc_test.clj
+++ b/test/midje_nrepl/misc_test.clj
@@ -1,0 +1,15 @@
+(ns midje-nrepl.misc-test
+  (:require [midje.sweet :refer :all]
+            [midje-nrepl.misc :as misc]))
+
+(facts "about miscellaneous functions"
+
+       (tabular (fact "returns true if the dependency is in the current project's classpath or false otherwise"
+                      (misc/dependency-in-classpath? ?dependency) => ?result)
+                ?dependency ?result
+                "clojure"    true
+                "cider-nrepl"    true
+                "refactor-nrepl"    true
+                "midje"    true
+                "amazonica"   false
+                "bouncycastle"   false))

--- a/test/midje_nrepl/nrepl_test.clj
+++ b/test/midje_nrepl/nrepl_test.clj
@@ -5,10 +5,10 @@
             [clojure.tools.nrepl.transport :as transport]
             [matcher-combinators.midje :refer [match]]
             [midje-nrepl.middleware.fake :as fake]
+            [midje-nrepl.misc :as misc]
             [midje-nrepl.nrepl
              :refer
              [defmiddleware middleware-vars-expected-by-wrap-inhibit-tests]]
-            [midje-nrepl.project-info :as project-info]
             [midje.sweet :refer :all]
             [refactor-nrepl.middleware :as refactor-nrepl]))
 
@@ -83,4 +83,4 @@ it replies to the message"
              (middleware-vars-expected-by-wrap-inhibit-tests)
              => #{#'eval/interruptible-eval #'cider/wrap-refresh}
              (provided
-              (project-info/dependency-in-classpath? "refactor-nrepl") => false)))
+              (misc/dependency-in-classpath? "refactor-nrepl") => false)))

--- a/test/midje_nrepl/plugin_test.clj
+++ b/test/midje_nrepl/plugin_test.clj
@@ -31,26 +31,28 @@
                                                         (assoc-in [:repl-options :nrepl-middleware]
                                                                   [`identity])))
 
-(def deps-with-only-midje-nrepl [['midje-nrepl "1.0.0"]])
+(def deps-with-midje-nrepl-and-clojure-tools-namespace [['midje-nrepl "1.0.0"]
+                                                        (m/equals ['org.clojure/tools.namespace #"^0\.3"])])
 
-(def deps-with-clojure-and-midje-nrepl [['org.clojure/clojure "1.9.0"]
-                                        ['midje-nrepl "1.0.0"]])
+(def deps-with-clojure-midje-nrepl-and-clojure-tools-namespace [['org.clojure/clojure "1.9.0"]
+                                                                ['midje-nrepl "1.0.0"]
+                                                                (m/equals ['org.clojure/tools.namespace #"^0\.3"])])
 
 (def midje-nrepl-middleware (m/in-any-order midje-nrepl/middleware))
 
 (def midje-nrepl-middleware-along-with-another-middleware (m/in-any-order (cons `identity midje-nrepl/middleware)))
 
 (def augmented-basic-project (assoc basic-project
-                                    :dependencies deps-with-only-midje-nrepl
+                                    :dependencies deps-with-midje-nrepl-and-clojure-tools-namespace
                                     :repl-options
                                     {:nrepl-middleware midje-nrepl-middleware}))
 
 (def augmented-project-with-repl-options (-> project-with-repl-options
-                                             (assoc                                     :dependencies deps-with-only-midje-nrepl)
+                                             (assoc                                     :dependencies deps-with-midje-nrepl-and-clojure-tools-namespace)
                                              (assoc-in [:repl-options :nrepl-middleware] midje-nrepl-middleware)))
 
 (def augmented-project-with-repl-options-and-nrepl-middleware (-> project-with-repl-options-and-nrepl-middleware
-                                                                  (assoc :dependencies deps-with-clojure-and-midje-nrepl)
+                                                                  (assoc :dependencies deps-with-clojure-midje-nrepl-and-clojure-tools-namespace)
                                                                   (assoc-in [:repl-options :nrepl-middleware] midje-nrepl-middleware-along-with-another-middleware)))
 
 (facts "about the Leiningen plugin"
@@ -60,7 +62,7 @@
        (tabular (fact "augments the project map by injecting midje-nrepl's middleware"
                       (plugin/middleware ?project)
                       => (match (m/equals ?augmented-project)))
-                ?project                                         ?augmented-project
-                basic-project                                    augmented-basic-project
-                project-with-repl-options                        augmented-project-with-repl-options
-                project-with-repl-options-and-nrepl-middleware  augmented-project-with-repl-options-and-nrepl-middleware))
+                ?project                                       ?augmented-project
+                basic-project                                  augmented-basic-project
+                project-with-repl-options                      augmented-project-with-repl-options
+                project-with-repl-options-and-nrepl-middleware augmented-project-with-repl-options-and-nrepl-middleware))

--- a/test/midje_nrepl/plugin_test.clj
+++ b/test/midje_nrepl/plugin_test.clj
@@ -21,6 +21,9 @@
                     :test-paths
                     '("/home/john-doe/projects/octocat/test")})
 
+(def project-with-conflicting-version-of-clojure-tools-namespace
+  (assoc basic-project :dependencies [['org.clojure/tools.namespace "0.2.11"]]))
+
 (def project-with-repl-options (assoc basic-project
                                       :repl-options {:host    "0.0.0.0"
                                                      :port    4001
@@ -64,5 +67,6 @@
                       => (match (m/equals ?augmented-project)))
                 ?project                                       ?augmented-project
                 basic-project                                  augmented-basic-project
+                project-with-conflicting-version-of-clojure-tools-namespace                                  augmented-basic-project
                 project-with-repl-options                      augmented-project-with-repl-options
                 project-with-repl-options-and-nrepl-middleware augmented-project-with-repl-options-and-nrepl-middleware))

--- a/test/midje_nrepl/project_info_test.clj
+++ b/test/midje_nrepl/project_info_test.clj
@@ -13,16 +13,6 @@
 
 (facts "about getting information of the current project"
 
-       (tabular (fact "returns true if the dependency is in the current project's classpath or false otherwise"
-                      (project-info/dependency-in-classpath? ?dependency) => ?result)
-                ?dependency ?result
-                "clojure"    true
-                "cider-nrepl"    true
-                "refactor-nrepl"    true
-                "midje"    true
-                "amazonica"   false
-                "bouncycastle"   false)
-
        (fact "returns a java.io.File representing the file where the namespace in question is declared"
              (.getPath (project-info/file-for-ns 'octocat.arithmetic-test))
              => #"test/octocat/arithmetic_test.clj$")


### PR DESCRIPTION
`midje-nrepl` depends on `org.clojure/tools.namespace` 0.3.x. If the project where `midje-nrepl` is running on
uses `org.clojure/tools.namespace` 0.2.x the REPL won't start or a `ClassNotFoundException` will be raised when the
namespace `project-info` is loaded.

This pull request provides a fix for the aforementioned problem by removing possible conflicting versions of
`org.clojure/tools.namespace` during the REPL startup and injecting the appropriate version.