### PR TITLE
Get proper descriptions for failing tabular facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - Support for running tests on [CircleCI](https://circleci.com/).
 
+### Fixed
+- Return proper descriptions for failing tabular facts.
+
 ## [1.0.0] - 2018-11-12
 
 ### Added

--- a/integration/integration/helpers.clj
+++ b/integration/integration/helpers.clj
@@ -7,7 +7,7 @@
 
 (defn- get-nrepl-port []
   (with-retry {:retry-on        [java.io.FileNotFoundException java.lang.NumberFormatException]
-               :max-duration-ms 60000}
+               :max-duration-ms 20000}
     (-> (io/file octocat-dir ".nrepl-port")
         slurp
         Integer/parseInt)))

--- a/integration/integration/inhibit_tests_test.clj
+++ b/integration/integration/inhibit_tests_test.clj
@@ -15,10 +15,6 @@
 (defn read-file-content [file-path]
   (slurp (io/file octocat file-path)))
 
-(defn map-without-key [key]
-  (fn [map]
-    (not (set/subset? #{key} (set (keys map))))))
-
 (facts "about evaluating code without running tests"
 
        (fact "the nREPL continues to evaluate sexprs normally even with the wrap-eval middleware in the stack"
@@ -30,8 +26,8 @@
              (send-message {:op        "load-file"
                             :file      (read-file-content core)
                             :file-path core})
-             => (match (list {:value "56"}
-                             {:status ["done"]})))
+             => (match [{:value "56"}
+                        {:status ["done"]}]))
 
        (fact "facts are evaluated but aren't run"
              (send-message {:op   "eval"
@@ -48,8 +44,8 @@
              (send-message {:op        "load-file"
                             :file      (read-file-content arithmetic-test)
                             :file-path arithmetic-test})
-             => (match (list (map-without-key :out)
-                             {:status ["done"]})))
+             => (match [{:value #"(nil)|(#'octocat.arithmetic-test.*)"}
+                        {:status ["done"]}]))
 
        (fact "facts are run when the client sends the parameter `load-tests?` set to true"
              (send-message {:op          "eval"

--- a/integration/integration/inhibit_tests_test.clj
+++ b/integration/integration/inhibit_tests_test.clj
@@ -33,12 +33,16 @@
              => (match (list {:value "56"}
                              {:status ["done"]})))
 
-       (fact "facts are evaluated but not run"
+       (fact "facts are evaluated but aren't run"
+             (send-message {:op   "eval"
+                            :code "(ns octocat.arithmetic-test
+(:require [midje.sweet :refer :all]))"})
+             =>             (match (m/embeds [{:status ["done"]}]))
              (send-message {:op   "eval"
                             :code "(fact 1 => 2)"
                             :ns   "octocat.arithmetic-test"})
-             => (match (list (map-without-key :out)
-                             {:status ["done"]})))
+             => (match (m/embeds [{:value #"(nil)|(#'octocat.arithmetic-test.*)"}
+                                  {:status ["done"]}])))
 
        (fact "files are evaluated but their facts aren't executed"
              (send-message {:op        "load-file"
@@ -47,7 +51,7 @@
              => (match (list (map-without-key :out)
                              {:status ["done"]})))
 
-       (fact "facts are run when the client sends the parameter `load-tests?` set as true"
+       (fact "facts are run when the client sends the parameter `load-tests?` set to true"
              (send-message {:op          "eval"
                             :load-tests? "true"
                             :code        "(fact 1 => 2)"
@@ -79,7 +83,7 @@
              (.exists hello-world-file)
              => false)
 
-       (facts "the Cider's wrap-refresh middleware continue working as expected"
+       (facts "the Cider's wrap-refresh middleware continues working as expected"
               (send-message {:op "refresh"})
               => (match (m/embeds [{:status ["ok"]}
                                    {:status ["done"]}])))

--- a/integration/integration/test_test.clj
+++ b/integration/integration/test_test.clj
@@ -79,6 +79,38 @@ it's possible to jump to the correct position of the test in question"
                               :summary {:check 1 :error 0 :fact 1 :fail 1 :ns 1 :pass 0 :to-do 0}}
                              {:status ["done"]})))
 
+       (fact "returns proper descriptions for failing tabular facts"
+             (send-message {:op     "midje-test"
+                            :ns     "octocat.arithmetic-test"
+                            :source "(tabular (fact \"some crazy additions\"
+               (+ ?x ?y) => ?result)
+  ?x ?y ?result
+   5  6      12)"})
+             => (match [{:results
+                         {:octocat.arithmetic-test [{:context ["some crazy additions"
+                                                               "With table substitutions:"
+                                                               "?x 5"
+                                                               "?y 6"
+                                                               "?result 12"]}]}}
+                        {:status (m/in-any-order ["done"])}]))
+
+       (fact "returns the top level description for a failing tabular fact when it is inside a `facts` form"
+             (send-message {:op     "midje-test"
+                            :ns     "octocat.arithmetic-test"
+                            :source "(facts \"about crazy operations\"
+(tabular (fact \"some crazy additions\"
+               (+ ?x ?y) => ?result)
+  ?x ?y ?result
+   5  6      12))"})
+             => (match [{:results
+                         {:octocat.arithmetic-test [{:context ["about crazy operations"
+                                                               "some crazy additions"
+                                                               "With table substitutions:"
+                                                               "?x 5"
+                                                               "?y 6"
+                                                               "?result 12"]}]}}
+                        {:status (m/in-any-order ["done"])}]))
+
        (fact "when the parameters ns and/or source are missing in the message,
 the middleware returns an error"
              (first (send-message {:op "midje-test"}))

--- a/test/midje_nrepl/reporter_test.clj
+++ b/test/midje_nrepl/reporter_test.clj
@@ -84,16 +84,16 @@
                                      :position ["arithmetic_test.clj" 15]
                                      :type     :some-prerequisites-were-called-the-wrong-number-of-times})
 
-(def failure-of-tabular-fact {:description          ["some crazy additions" nil]
-                              :arrow                '=>
-                              :call-form            (+ 5 6)
-                              :expected-result-form 12
-                              :check-expectation    :expect-match
-                              :midje/table-bindings {'?x 5 '?y 6 '?result 12}
-                              :type                 :actual-result-did-not-match-expected-value
-                              :expected-result      12
-                              :actual               11
-                              :position             ["octocat.arithmetic-test" 51]})
+(def failure-with-table-bindings {:description          ["some crazy additions" nil]
+                                  :arrow                '=>
+                                  :call-form            (+ 5 6)
+                                  :expected-result-form 12
+                                  :check-expectation    :expect-match
+                                  :midje/table-bindings {'?x 5 '?y 6 '?result 12}
+                                  :type                 :actual-result-did-not-match-expected-value
+                                  :expected-result      12
+                                  :actual               11
+                                  :position             ["octocat.arithmetic-test" 51]})
 
 (def arithmetic-test-file (io/file "/home/john-doe/dev/octocat/test/octocat/arithmetic_test.clj"))
 
@@ -238,7 +238,7 @@ it is interpreted as an error in the test report"
        (fact "treats failing tabular facts properly"
              (reporter/starting-to-check-top-level-fact failing-tabular-fact-function)
              (reporter/starting-to-check-fact failing-tabular-fact-function)
-             (reporter/fail failure-of-tabular-fact)
+             (reporter/fail failure-with-table-bindings)
              @reporter/report => (match {:results {'octocat.arithmetic-test
                                                    [{:context ["this is inquestionable"]
                                                      :index   0

--- a/test/midje_nrepl/reporter_test.clj
+++ b/test/midje_nrepl/reporter_test.clj
@@ -35,12 +35,9 @@
                                          :top-level-fact? true}))
 
 (def failing-tabular-fact-function (with-meta (constantly false)
-                                     #:midje{:description     ["some crazy additions" nil]
-                                             :table-bindings  {'?x 5 '?y 6 '?result 12}
-                                             :guid            "bc65e9bd20065ba5449ba7f0254e9907c5e9ffe5"
+                                     #:midje{:guid            "bc65e9bd20065ba5449ba7f0254e9907c5e9ffe5"
                                              :source          '(fact (+ 5 6) => 12)
                                              :namespace       'octocat.arithmetic-test
-                                             :line            41
                                              :top-level-fact? false}))
 
 (def failure-with-simple-mismatch {:actual               1
@@ -96,7 +93,7 @@
                               :type                 :actual-result-did-not-match-expected-value
                               :expected-result      12
                               :actual               11
-                              :line                 41})
+                              :position             ["octocat.arithmetic-test" 51]})
 
 (def arithmetic-test-file (io/file "/home/john-doe/dev/octocat/test/octocat/arithmetic_test.clj"))
 
@@ -281,6 +278,7 @@ it is interpreted as an error in the test report"
                                                                 "?result 12"]
                                                      :expected "12\n"
                                                      :file     expected-file?
+                                                     :line     51
                                                      :index    4
                                                      :message  ()
                                                      :ns       'octocat.arithmetic-test

--- a/test/midje_nrepl/reporter_test.clj
+++ b/test/midje_nrepl/reporter_test.clj
@@ -34,6 +34,15 @@
                                          :name            "this is impossible"
                                          :top-level-fact? true}))
 
+(def failing-tabular-fact-function (with-meta (constantly false)
+                                     #:midje{:description     ["some crazy additions" nil]
+                                             :table-bindings  {'?x 5 '?y 6 '?result 12}
+                                             :guid            "bc65e9bd20065ba5449ba7f0254e9907c5e9ffe5"
+                                             :source          '(fact (+ 5 6) => 12)
+                                             :namespace       'octocat.arithmetic-test
+                                             :line            41
+                                             :top-level-fact? false}))
+
 (def failure-with-simple-mismatch {:actual               1
                                    :arrow                '=>
                                    :call-form            1
@@ -77,6 +86,17 @@
                                                   :position             ["arithmetic_test.clj" 15]})
                                      :position ["arithmetic_test.clj" 15]
                                      :type     :some-prerequisites-were-called-the-wrong-number-of-times})
+
+(def failure-of-tabular-fact {:description          ["some crazy additions" nil]
+                              :arrow                '=>
+                              :call-form            (+ 5 6)
+                              :expected-result-form 12
+                              :check-expectation    :expect-match
+                              :midje/table-bindings {'?x 5 '?y 6 '?result 12}
+                              :type                 :actual-result-did-not-match-expected-value
+                              :expected-result      12
+                              :actual               11
+                              :line                 41})
 
 (def arithmetic-test-file (io/file "/home/john-doe/dev/octocat/test/octocat/arithmetic_test.clj"))
 
@@ -218,12 +238,62 @@ it is interpreted as an error in the test report"
                                                      :line    25
                                                      :type    :to-do}]}}))
 
+       (fact "treats failing tabular facts properly"
+             (reporter/starting-to-check-top-level-fact failing-tabular-fact-function)
+             (reporter/starting-to-check-fact failing-tabular-fact-function)
+             (reporter/fail failure-of-tabular-fact)
+             @reporter/report => (match {:results {'octocat.arithmetic-test
+                                                   [{:context ["this is inquestionable"]
+                                                     :index   0
+                                                     :ns      'octocat.arithmetic-test
+                                                     :file    expected-file?
+                                                     :line    10
+                                                     :source  "(fact \"this is inquestionable\" 1 => 1)"
+                                                     :type    :pass}
+                                                    {:context  ["this is wrong"]
+                                                     :index    1
+                                                     :ns       'octocat.arithmetic-test
+                                                     :file     expected-file?
+                                                     :line     15
+                                                     :source   "(fact \"this is wrong\" 1 => 2)"
+                                                     :expected "2\n"
+                                                     :actual   "1\n"
+                                                     :message  '()
+                                                     :type     :fail}
+                                                    {:context  ["this is impossible"]
+                                                     :index    2
+                                                     :ns       'octocat.arithmetic-test
+                                                     :file     expected-file?
+                                                     :line     20
+                                                     :source   "(fact \"this is impossible\" (/ 10 0) => 0)"
+                                                     :expected "0\n"
+                                                     :error    #(= arithmetic-exception %)
+                                                     :type     :error}
+                                                    {:context ["TODO"]
+                                                     :index   3
+                                                     :line    25
+                                                     :type    :to-do}
+                                                    {:actual   "11\n"
+                                                     :context  ["some crazy additions"
+                                                                "With table substitutions:"
+                                                                "?x 5"
+                                                                "?y 6"
+                                                                "?result 12"]
+                                                     :expected "12\n"
+                                                     :file     expected-file?
+                                                     :index    4
+                                                     :message  ()
+                                                     :ns       'octocat.arithmetic-test
+                                                     :source   "(fact (+ 5 6) => 12)"
+                                                     :type     :fail}]}})
+             (reporter/finishing-top-level-fact failing-tabular-fact-function))
+
        (fact "summarizes test results, by computing the counters for each category"
              (reporter/summarize-test-results!)
-             @reporter/report => (match {:summary {:check 4
+             @reporter/report => (match {:summary {:check 5
                                                    :error 1
-                                                   :fact  3
-                                                   :fail  1
+                                                   :fact  4
+                                                   :fail  2
                                                    :ns    1
                                                    :pass  1
                                                    :to-do 1}}))

--- a/test/midje_nrepl/test_runner_test.clj
+++ b/test/midje_nrepl/test_runner_test.clj
@@ -162,12 +162,10 @@
 
 (facts "about running tests in a given namespace"
 
-       (tabular (fact "runs all tests in the given namespace"
-                      (test-runner/run-tests-in-ns ?namespace) => (match ?report))
-                ?namespace                ?report
-                'octocat.arithmetic-test arithmetic-test-report
-                'octocat.colls-test      colls-test-report
-                'octocat.mocks-test      mocks-test-report)
+       (fact "runs all tests in the given namespace"
+             (test-runner/run-tests-in-ns 'octocat.arithmetic-test) => (match arithmetic-test-report)
+             (test-runner/run-tests-in-ns 'octocat.colls-test) => (match colls-test-report)
+             (test-runner/run-tests-in-ns 'octocat.mocks-test) => (match mocks-test-report))
 
        (fact "returns a report with no tests when there are no tests to be run"
              (test-runner/run-tests-in-ns 'octocat.no-tests)


### PR DESCRIPTION
Prior this pull request midje-nrepl was returning the fact's source as the
description of a failing tabular fact. As of now, it will return a description
similar to what Midje shows when a tabular fact fails:
```clojure
{:context ["about crazy operations"
                                                               "some crazy additions"
                                                               "With table substitutions:"
                                                               "?x 5"
                                                               "?y 6"
                                                               "?result 12"]}
```