### PR TITLE
Support selecting test paths where facts will run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Allow for nREPL clients to run all tests in a subset of the known test paths
+  of the project, by sending the parameter `test-paths` in the message.
+
 ## [1.0.1] - 2018-12-05
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ teardown-integration:
 	@cd $(octocat); \
 	pid=$$(cat .nrepl-pid); \
 	pkill --parent $$pid && \
-	rm .nrepl-pid .nrepl-port
+	rm -f .nrepl-pid .nrepl-port
 	@echo "Done"
 
 test-integration: setup-integration

--- a/dev-resources/octocat/integration/integration/database_test.clj
+++ b/dev-resources/octocat/integration/integration/database_test.clj
@@ -1,0 +1,11 @@
+(ns integration.database-test
+  (:require [midje.sweet :refer :all]))
+
+(defn find-all-users []
+  [{:first-name "John" :last-name "Doe"}])
+
+(facts "about database operations"
+
+       (fact "finds all users in the system"
+             (find-all-users)
+             => [{:first-name "John" :last-name "Doe"}]))

--- a/dev-resources/octocat/project.clj
+++ b/dev-resources/octocat/project.clj
@@ -5,7 +5,7 @@
   :plugins [[lein-midje "3.2.1"]]
 
   :dependencies [[org.clojure/clojure "1.9.0"]]
-  :profiles {:dev {:dependencies [[midje "1.9.2-alpha3"]]}}
+  :profiles {:dev {:dependencies [[midje "1.9.4"]]}}
 
   :test-paths ["test" "integration"]
 

--- a/dev-resources/octocat/project.clj
+++ b/dev-resources/octocat/project.clj
@@ -7,4 +7,6 @@
   :dependencies [[org.clojure/clojure "1.9.0"]]
   :profiles {:dev {:dependencies [[midje "1.9.2-alpha3"]]}}
 
+  :test-paths ["test" "integration"]
+
   :repl-options {:timeout 7000})

--- a/integration/integration/helpers.clj
+++ b/integration/integration/helpers.clj
@@ -7,7 +7,7 @@
 
 (defn- get-nrepl-port []
   (with-retry {:retry-on        [java.io.FileNotFoundException java.lang.NumberFormatException]
-               :max-duration-ms 40000}
+               :max-duration-ms 60000}
     (-> (io/file octocat-dir ".nrepl-port")
         slurp
         Integer/parseInt)))

--- a/integration/integration/inhibit_tests_test.clj
+++ b/integration/integration/inhibit_tests_test.clj
@@ -72,7 +72,7 @@
        (fact "the warm-ast-cache middleware continues working as expected"
              (safe-delete-hello-world-file)
              (send-message {:op "warm-ast-cache"})
-             => (match [{:ast-statuses "(octocat.arithmetic-test \"OK\" octocat.side-effects-test \"OK\")"
+             => (match [{:ast-statuses "(integration.database-test \"OK\" octocat.arithmetic-test \"OK\" octocat.side-effects-test \"OK\")"
                          :status       ["done"]}]))
 
        (fact "Midje facts weren't run by the warm-ast-cache middleware, so the file hello-world.txt wasn't created again"

--- a/integration/integration/test_info.clj
+++ b/integration/integration/test_info.clj
@@ -1,0 +1,28 @@
+(ns integration.test-info
+  (:require [integration.helpers :refer [send-message]]
+            [matcher-combinators.midje :refer [match]]
+            [midje.sweet :refer :all]))
+
+(facts "about getting information about test paths and namespaces"
+
+       (fact "gets all known test paths in the project"
+             (send-message {:op "test-paths"})
+             => (match [{:test-paths ["integration" "test"]}
+                        {:status ["done"]}]))
+
+       (fact "gets all test namespaces defined in the project"
+             (send-message {:op "test-namespaces"})
+             => (match [{:test-namespaces ["integration.database-test"
+                                           "octocat.arithmetic-test"
+                                           "octocat.side-effects-test"]}
+                        {:status ["done"]}]))
+
+       (tabular (fact "by sending the parameter `test-paths`, clients can find namespaces only in the mentioned test paths"
+                      (send-message {:op         "test-namespaces"
+                                     :test-paths ?test-paths})
+                      => (match [{:test-namespaces ?namespaces}
+                                 {:status ["done"]}]))
+                ?test-paths                                                                         ?namespaces
+                ["test"]                             ["octocat.arithmetic-test" "octocat.side-effects-test"]
+                ["integration"]                                                       ["integration.database-test"]
+                ["integration" "test"] ["integration.database-test" "octocat.arithmetic-test" "octocat.side-effects-test"]))

--- a/integration/integration/test_test.clj
+++ b/integration/integration/test_test.clj
@@ -138,6 +138,14 @@ the middleware returns an error"
                               :summary {:check 7 :error 1 :fact 6 :fail 2 :ns 3 :pass 4 :to-do 0}}
                              {:status ["done"]})))
 
+       (fact "runs all tests in the specified test path"
+             (send-message {:op         "midje-test-all"
+                            :test-paths ["test"]})
+             => (match (list {:results {:octocat.arithmetic-test   (complement empty?)
+                                        :octocat.side-effects-test (complement empty?)}
+                              :summary {:check 6 :error 1 :fact 5 :fail 2 :ns 2 :pass 3 :to-do 0}}
+                             {:status ["done"]})))
+
        (fact "re-runs tests that didn't pass in the previous execution"
              (send-message {:op "midje-test-ns" :ns "octocat.arithmetic-test"})
              => irrelevant

--- a/integration/integration/test_test.clj
+++ b/integration/integration/test_test.clj
@@ -133,8 +133,9 @@ the middleware returns an error"
        (fact "runs all tests in the project"
              (send-message {:op "midje-test-all"})
              => (match (list {:results {:octocat.arithmetic-test   (complement empty?)
-                                        :octocat.side-effects-test (complement empty?)}
-                              :summary {:check 6 :error 1 :fact 5 :fail 2 :ns 2 :pass 3 :to-do 0}}
+                                        :octocat.side-effects-test (complement empty?)
+                                        :integration.database-test (complement empty?)}
+                              :summary {:check 7 :error 1 :fact 6 :fail 2 :ns 3 :pass 4 :to-do 0}}
                              {:status ["done"]})))
 
        (fact "re-runs tests that didn't pass in the previous execution"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/midje-nrepl "1.0.2-SNAPSHOT"
+(defproject nubank/midje-nrepl "1.1.0-SNAPSHOT"
   :description "nREPL middleware to interact with Midje"
   :url "https://github.com/nubank/midje-nrepl"
   :license {:name "Apache License, Version 2.0"

--- a/src/midje_nrepl/middleware/test.clj
+++ b/src/midje_nrepl/middleware/test.clj
@@ -2,14 +2,16 @@
   (:require [cider.nrepl.middleware.stacktrace :as stacktrace]
             [clojure.tools.nrepl.misc :refer [response-for]]
             [clojure.tools.nrepl.transport :as transport]
+            [midje-nrepl.project-info :as project-info]
             [midje-nrepl.test-runner :as test-runner]
             [orchard.misc :as misc]))
 
 (defn- send-report [{:keys [transport] :as message} report]
   (transport/send transport (response-for message (misc/transform-value report))))
 
-(defn- test-all-reply [message]
-  (let [report (test-runner/run-all-tests)]
+(defn- test-all-reply [{:keys [test-paths] :as message}]
+  (let [test-paths (or test-paths (project-info/get-test-paths))
+        report     (test-runner/run-all-tests-in test-paths)]
     (send-report message report)))
 
 (defn- test-ns-reply [{:keys [ns] :as message}]

--- a/src/midje_nrepl/middleware/test_info.clj
+++ b/src/midje_nrepl/middleware/test_info.clj
@@ -5,7 +5,8 @@
             [orchard.misc :as misc]))
 
 (defn- test-namespaces-reply [{:keys [transport test-paths] :as message}]
-  (let [test-namespaces (project-info/get-test-namespaces-in test-paths)]
+  (let [test-paths      (or test-paths (project-info/get-test-paths))
+        test-namespaces (project-info/get-test-namespaces-in test-paths)]
     (transport/send transport
                     (response-for message :test-namespaces (misc/transform-value test-namespaces)))))
 

--- a/src/midje_nrepl/middleware/test_info.clj
+++ b/src/midje_nrepl/middleware/test_info.clj
@@ -1,0 +1,20 @@
+(ns midje-nrepl.middleware.test-info
+  (:require [clojure.tools.nrepl.misc :refer [response-for]]
+            [clojure.tools.nrepl.transport :as transport]
+            [midje-nrepl.project-info :as project-info]
+            [orchard.misc :as misc]))
+
+(defn- test-namespaces-reply [{:keys [transport test-paths] :as message}]
+  (let [test-namespaces (project-info/get-test-namespaces-in test-paths)]
+    (transport/send transport
+                    (response-for message :test-namespaces (misc/transform-value test-namespaces)))))
+
+(defn- test-paths-reply [{:keys [transport] :as message}]
+  (transport/send transport
+                  (response-for message :test-paths (project-info/get-test-paths))))
+
+(defn handle-test-info [{:keys [op transport] :as message}]
+  (case op
+    "test-paths"      (test-paths-reply message)
+    "test-namespaces" (test-namespaces-reply message))
+  (transport/send transport (response-for message :status :done)))

--- a/src/midje_nrepl/nrepl.clj
+++ b/src/midje_nrepl/nrepl.clj
@@ -103,6 +103,15 @@
                           "print-fn" "Fully qualified name of a print function that will be used to print stacktraces."}}}}
   'midje-nrepl.middleware.test/handle-test)
 
+(defmiddleware wrap-test-info
+  {:handles {"test-paths"
+             {:doc "Returns a list of known test paths for the current project."}
+             "test-namespaces"
+             {:doc      "Returns a list of test namespaces declared within specified test paths."
+              :optional {"test-paths" "A list of test paths to find namespaces
+  in. If omitted find namespaces in all known test paths."}}}}
+  'midje-nrepl.middleware.test-info)
+
 (defmiddleware wrap-version
   {:expects  #{}
    :requires #{}
@@ -113,4 +122,5 @@
 (def middleware `[wrap-format
                   wrap-inhibit-tests
                   wrap-test
+                  wrap-test-info
                   wrap-version])

--- a/src/midje_nrepl/nrepl.clj
+++ b/src/midje_nrepl/nrepl.clj
@@ -110,7 +110,7 @@
              {:doc      "Returns a list of test namespaces declared within specified test paths."
               :optional {"test-paths" "A list of test paths to find namespaces
   in. If omitted find namespaces in all known test paths."}}}}
-  'midje-nrepl.middleware.test-info)
+  'midje-nrepl.middleware.test-info/handle-test-info)
 
 (defmiddleware wrap-version
   {:expects  #{}

--- a/src/midje_nrepl/test_runner.clj
+++ b/src/midje_nrepl/test_runner.clj
@@ -68,13 +68,12 @@
              :summary (merge-with + (:summary a) (:summary b))})
           reporter/no-tests reports))
 
-(defn run-all-tests []
-  (let [test-paths (project-info/get-test-paths)]
-    (caching-test-results
-     (->> test-paths
-          project-info/get-test-namespaces-in
-          (map #(check-facts :ns %))
-          merge-test-reports))))
+(defn run-all-tests-in [test-paths]
+  (caching-test-results
+   (->> test-paths
+        project-info/get-test-namespaces-in
+        (map #(check-facts :ns %))
+        merge-test-reports)))
 
 (defn- non-passing-tests [[namespace results]]
   (let [non-passing-items (filter #(#{:error :fail} (:type %)) results)]

--- a/test/midje_nrepl/middleware/test_info_test.clj
+++ b/test/midje_nrepl/middleware/test_info_test.clj
@@ -24,4 +24,15 @@
              (provided
               (project-info/get-test-namespaces-in ["test"]) => ['octocat.arithmetic-test 'octocat.colls-test]
               (transport/send ..transport.. (match {:test-namespaces ["octocat.arithmetic-test" "octocat.colls-test"]})) => irrelevant
+              (transport/send ..transport.. (match {:status #{:done}})) => irrelevant))
+
+       (fact "when the parameter `test-paths` is omitted,
+returns a list of all known test namespaces"
+             (test-info/handle-test-info {:op        "test-namespaces"
+                                          :transport ..transport..})
+             => irrelevant
+             (provided
+              (project-info/get-test-paths) => ["src/clojure/test" "test"]
+              (project-info/get-test-namespaces-in ["src/clojure/test" "test"]) => ['octocat.arithmetic-test 'octocat.colls-test 'octocat.mocks-test]
+              (transport/send ..transport.. (match {:test-namespaces ["octocat.arithmetic-test" "octocat.colls-test" "octocat.mocks-test"]})) => irrelevant
               (transport/send ..transport.. (match {:status #{:done}})) => irrelevant)))

--- a/test/midje_nrepl/middleware/test_info_test.clj
+++ b/test/midje_nrepl/middleware/test_info_test.clj
@@ -1,0 +1,27 @@
+(ns midje-nrepl.middleware.test-info-test
+  (:require [clojure.tools.nrepl.transport :as transport]
+            [matcher-combinators.midje :refer [match]]
+            [midje-nrepl.middleware.test-info :as test-info]
+            [midje-nrepl.project-info :as project-info]
+            [midje.sweet :refer :all]))
+
+(facts "about getting information about test paths and namespaces"
+
+       (fact "returns the project's test paths"
+             (test-info/handle-test-info {:op        "test-paths"
+                                          :transport ..transport..})
+             => irrelevant
+             (provided
+              (project-info/get-test-paths) => ["test" "integration"]
+              (transport/send ..transport.. (match {:test-paths ["test" "integration"]})) => irrelevant
+              (transport/send ..transport.. (match {:status #{:done}})) => irrelevant))
+
+       (fact "returns the test namespaces declared within a given test path"
+             (test-info/handle-test-info {:op         "test-namespaces"
+                                          :transport  ..transport..
+                                          :test-paths ["test"]})
+             => irrelevant
+             (provided
+              (project-info/get-test-namespaces-in ["test"]) => ['octocat.arithmetic-test 'octocat.colls-test]
+              (transport/send ..transport.. (match {:test-namespaces ["octocat.arithmetic-test" "octocat.colls-test"]})) => irrelevant
+              (transport/send ..transport.. (match {:status #{:done}})) => irrelevant)))

--- a/test/midje_nrepl/middleware/test_test.clj
+++ b/test/midje_nrepl/middleware/test_test.clj
@@ -3,6 +3,7 @@
             [clojure.tools.nrepl.transport :as transport]
             [matcher-combinators.midje :refer [match]]
             [midje-nrepl.middleware.test :as test]
+            [midje-nrepl.project-info :as project-info]
             [midje-nrepl.test-runner :as test-runner]
             [midje.sweet :refer :all]
             [orchard.misc :as misc]))
@@ -29,7 +30,18 @@
              (test/handle-test {:op        "midje-test-all"
                                 :transport ..transport..}) => irrelevant
              (provided
-              (test-runner/run-all-tests) => test-report
+              (project-info/get-test-paths) => ["test"]
+              (test-runner/run-all-tests-in ["test"]) => test-report
+              (transport/send ..transport.. transformed-report) => irrelevant
+              (transport/send ..transport.. (match {:status #{:done}})) => irrelevant))
+
+       (fact "clients can pass a `test-paths` parameter, in order to restrict the test execution to desired paths"
+             (test/handle-test {:op         "midje-test-all"
+                                :test-paths ["src/clojure/test"]
+                                :transport  ..transport..}) => irrelevant
+             (provided
+              (project-info/get-test-paths) => irrelevant :times 0
+              (test-runner/run-all-tests-in ["src/clojure/test"]) => test-report
               (transport/send ..transport.. transformed-report) => irrelevant
               (transport/send ..transport.. (match {:status #{:done}})) => irrelevant))
 

--- a/test/midje_nrepl/test_runner_test.clj
+++ b/test/midje_nrepl/test_runner_test.clj
@@ -203,22 +203,20 @@
              => (match (:results individual-test-report))))
 
 (facts "about running all tests in the project"
-       (against-background
-        (project-info/get-test-paths) => ["test/octocat"])
 
        (fact "runs all tests in the project"
-             (test-runner/run-all-tests)
+             (test-runner/run-all-tests-in ["test/octocat"])
              => (match all-tests-report))
 
        (fact "returns a report with no tests when there are no tests to be run"
-             (test-runner/run-all-tests)
+             (test-runner/run-all-tests-in ["test/octocat"])
              => (match {:results {}
                         :summary {:check 0 :ns 0}})
              (provided
               (project-info/get-test-namespaces-in ["test/octocat"]) => ['octocat.no-tests]))
 
        (fact "results of the last execution are kept in the current session"
-             (test-runner/run-all-tests)
+             (test-runner/run-all-tests-in ["test/octocat"])
              => (match all-tests-report)
              @test-runner/test-results
              => (match (:results all-tests-report))))


### PR DESCRIPTION
Allow for nREPL clients to run all tests in a subset of the known test paths
of the project, by sending the parameter `test-paths` in the message.