### PR TITLE
Add basic filter capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- [#12](https://github.com/nubank/midje-nrepl/pull/12): add two new options to
+  `wrap-test` middleware, `:ns-exclusions` and `:ns-inclusions`. Those options
+  allow for clients to send lists of regexes to filter namespaces to be excluded
+  or included from/to the test execution.
+
 ## [1.1.0] - 2018-12-19
 
 ### Added

--- a/integration/integration/test_info_test.clj
+++ b/integration/integration/test_info_test.clj
@@ -1,4 +1,4 @@
-(ns integration.test-info
+(ns integration.test-info-test
   (:require [integration.helpers :refer [send-message]]
             [matcher-combinators.midje :refer [match]]
             [midje.sweet :refer :all]))

--- a/integration/integration/test_test.clj
+++ b/integration/integration/test_test.clj
@@ -146,10 +146,10 @@ the middleware returns an error"
                               :summary {:check 6 :error 1 :fact 5 :fail 2 :ns 2 :pass 3 :to-do 0}}
                              {:status ["done"]})))
 
-       (fact "uses exclusions/inclusions to test only a subset of namespaces"
-             (-> (send-message {:op         "midje-test-all"
-                                :inclusions "^octocat"
-                                :exclusions "side-effects-test"})
+       (fact "uses ns-exclusions/ns-inclusions to test only a subset of namespaces"
+             (-> (send-message {:op            "midje-test-all"
+                                :ns-inclusions ["^octocat"]
+                                :ns-exclusions ["side-effects-test"]})
                  first
                  :results
                  keys)

--- a/integration/integration/test_test.clj
+++ b/integration/integration/test_test.clj
@@ -146,6 +146,15 @@ the middleware returns an error"
                               :summary {:check 6 :error 1 :fact 5 :fail 2 :ns 2 :pass 3 :to-do 0}}
                              {:status ["done"]})))
 
+       (fact "uses exclusions/inclusions to test only a subset of namespaces"
+             (-> (send-message {:op         "midje-test-all"
+                                :inclusions "^octocat"
+                                :exclusions "side-effects-test"})
+                 first
+                 :results
+                 keys)
+             => (match [:octocat.arithmetic-test]))
+
        (fact "re-runs tests that didn't pass in the previous execution"
              (send-message {:op "midje-test-ns" :ns "octocat.arithmetic-test"})
              => irrelevant

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/midje-nrepl "1.1.1-SNAPSHOT"
+(defproject nubank/midje-nrepl "1.2.0-SNAPSHOT"
   :description "nREPL middleware to interact with Midje"
   :url "https://github.com/nubank/midje-nrepl"
   :license {:name "Apache License, Version 2.0"

--- a/src/midje_nrepl/middleware/test.clj
+++ b/src/midje_nrepl/middleware/test.clj
@@ -2,16 +2,18 @@
   (:require [cider.nrepl.middleware.stacktrace :as stacktrace]
             [clojure.tools.nrepl.misc :refer [response-for]]
             [clojure.tools.nrepl.transport :as transport]
-            [midje-nrepl.project-info :as project-info]
+            [midje-nrepl.misc :as misc]
             [midje-nrepl.test-runner :as test-runner]
-            [orchard.misc :as misc]))
+            [orchard.misc :refer [transform-value]]))
 
 (defn- send-report [{:keys [transport] :as message} report]
-  (transport/send transport (response-for message (misc/transform-value report))))
+  (transport/send transport (response-for message (transform-value report))))
 
-(defn- test-all-reply [{:keys [test-paths] :as message}]
-  (let [test-paths (or test-paths (project-info/get-test-paths))
-        report     (test-runner/run-all-tests-in test-paths)]
+(defn- test-all-reply [message]
+  (let [options (misc/parse-options message {:test-paths identity
+                                             :exclusions re-pattern
+                                             :inclusions re-pattern})
+        report  (test-runner/run-all-tests options)]
     (send-report message report)))
 
 (defn- test-ns-reply [{:keys [ns] :as message}]

--- a/src/midje_nrepl/middleware/test.clj
+++ b/src/midje_nrepl/middleware/test.clj
@@ -10,10 +10,11 @@
   (transport/send transport (response-for message (transform-value report))))
 
 (defn- test-all-reply [message]
-  (let [options (misc/parse-options message {:test-paths identity
-                                             :exclusions re-pattern
-                                             :inclusions re-pattern})
-        report  (test-runner/run-all-tests options)]
+  (let [strings->regexes #(map re-pattern %)
+        options          (misc/parse-options message {:test-paths    identity
+                                                      :ns-exclusions strings->regexes
+                                                      :ns-inclusions strings->regexes})
+        report           (test-runner/run-all-tests options)]
     (send-report message report)))
 
 (defn- test-ns-reply [{:keys [ns] :as message}]

--- a/src/midje_nrepl/middleware/test_info.clj
+++ b/src/midje_nrepl/middleware/test_info.clj
@@ -6,7 +6,7 @@
 
 (defn- test-namespaces-reply [{:keys [transport test-paths] :as message}]
   (let [test-paths      (or test-paths (project-info/get-test-paths))
-        test-namespaces (project-info/get-test-namespaces-in test-paths)]
+        test-namespaces (project-info/find-namespaces-in test-paths)]
     (transport/send transport
                     (response-for message :test-namespaces (misc/transform-value test-namespaces)))))
 

--- a/src/midje_nrepl/misc.clj
+++ b/src/midje_nrepl/misc.clj
@@ -9,3 +9,10 @@
          (map #(.getPath %))
          (some (partial re-find pattern))
          boolean)))
+
+(defn parse-options [options parsers-map]
+  (reduce (fn [result [key parse-fn]]
+            (if-let [value (get options key)]
+              (assoc result key (parse-fn value))
+              result)
+            ) {} parsers-map))

--- a/src/midje_nrepl/misc.clj
+++ b/src/midje_nrepl/misc.clj
@@ -10,7 +10,12 @@
          (some (partial re-find pattern))
          boolean)))
 
-(defn parse-options [options parsers-map]
+(defn parse-options
+  "Takes a map of options (key -> value) and a map of parsers (key ->
+  parser function). Applies each parser function to the corresponding
+  value in the options map, returning a new map of key -> parsed
+  values."
+  [options parsers-map]
   (reduce (fn [result [key parse-fn]]
             (if-let [value (get options key)]
               (assoc result key (parse-fn value))

--- a/src/midje_nrepl/project_info.clj
+++ b/src/midje_nrepl/project_info.clj
@@ -28,14 +28,20 @@
 (defn existing-dir? [candidate]
   (.isDirectory (io/file (project-working-dir) candidate)))
 
-(defn get-test-paths []
+(defn- get-project-paths [key default]
   (let [project-map (read-project-map)]
-    (->> (get project-map :test-paths ["test"])
+    (->> (get project-map key [default])
          (filter existing-dir?)
          sort)))
 
-(defn get-test-namespaces-in [test-paths]
-  (->> test-paths
+(def get-source-paths
+  #(get-project-paths :source-paths "src"))
+
+(def get-test-paths
+  #(get-project-paths :test-paths "test"))
+
+(defn find-namespaces-in [paths]
+  (->> paths
        (map (partial io/file (project-working-dir)))
        (mapcat namespace.find/find-namespaces-in-dir)
        sort))

--- a/src/midje_nrepl/test_runner.clj
+++ b/src/midje_nrepl/test_runner.clj
@@ -72,13 +72,23 @@
           reporter/no-tests reports))
 
 (defn run-all-tests
+  "Runs all tests in the project or a subset of them, depending upon the supplied options.
+
+  options is a PersistentMap with the valid keys:
+  :inclusions - a regex to match namespaces against.
+  :exclusions - a regex to match namespaces against. When both
+  exclusions and inclusions are present, the former takes precedence
+  over the later.
+  :test-paths - a vector of test paths (strings) to restrict the test
+  execution. Defaults to all known test paths declared in the
+  project."
   [options]
   (let [{:keys [exclusions inclusions test-paths]
          :or   {test-paths (project-info/get-test-paths)}} options
-        namespaces                                       (-> (project-info/find-namespaces-in test-paths)
-                                                             (cond->>
-                                                                 inclusions (filter #(re-find inclusions (name %)))
-                                                                 exclusions (remove #(re-find exclusions (name %)))))]
+        namespaces                                         (-> (project-info/find-namespaces-in test-paths)
+                                                               (cond->>
+                                                                   inclusions (filter #(re-find inclusions (name %)))
+                                                                   exclusions (remove #(re-find exclusions (name %)))))]
     (saving-test-results!
      (->> namespaces
           (map #(check-facts :ns %))

--- a/src/midje_nrepl/test_runner.clj
+++ b/src/midje_nrepl/test_runner.clj
@@ -71,7 +71,7 @@
 (defn run-all-tests-in [test-paths]
   (caching-test-results
    (->> test-paths
-        project-info/get-test-namespaces-in
+        project-info/find-namespaces-in
         (map #(check-facts :ns %))
         merge-test-reports)))
 

--- a/test/midje_nrepl/formatter_test.clj
+++ b/test/midje_nrepl/formatter_test.clj
@@ -3,22 +3,23 @@
             [midje-nrepl.formatter :as formatter]
             [midje.sweet :refer :all]))
 
-(tabular (fact "determines the padding left and right to the supplied text according to the alignment option and the width"
-           (formatter/paddings ?text ?alignment ?width)
-           => {:padding-left  ?padding-left
-               :padding-right ?padding-right})
-  ?text ?alignment ?width ?padding-left ?padding-right
-  "text" :center 4 0 0
-  "text" :center 13 4 5
-  "hello" :center 15 5 5
-  "text" :center 20 8 8
-  "hello" :center 20 7 8
-  "text" :left 4 0 0
-  "text" :left 20 0 16
-  "text" :right 4 0 0
-  "text" :right 20 16 0
-  "hello" :left 11 0 6
-  "hello" :right 15 10 0)
+(facts "about calculating padding values for a given text"
+       (tabular (fact "determines the padding left and right to the supplied text according to the alignment option and the width"
+                      (formatter/paddings ?text ?alignment ?width)
+                      => {:padding-left  ?padding-left
+                          :padding-right ?padding-right})
+                ?text ?alignment ?width ?padding-left ?padding-right
+                "text" :center 4 0 0
+                "text" :center 13 4 5
+                "hello" :center 15 5 5
+                "text" :center 20 8 8
+                "hello" :center 20 7 8
+                "text" :left 4 0 0
+                "text" :left 20 0 16
+                "text" :right 4 0 0
+                "text" :right 20 16 0
+                "hello" :left 11 0 6
+                "hello" :right 15 10 0))
 
 (def table ["?x" "?y" "?result"
             "4" "5" "9"
@@ -40,12 +41,13 @@
                      {:leftmost-cell? true :padding-left 0 :padding-right 1} {:padding-left 1 :padding-right 1} {:rightmost-cell? true :padding-left 2 :padding-right 2}
                      {:leftmost-cell? true :padding-left 0 :padding-right 0} {:padding-left 0 :padding-right 0} {:rightmost-cell? true :padding-left 1 :padding-right 2}])
 
-(tabular (fact "determines the paddings for the supplied table according to the alignment options"
-           (formatter/paddings-for-cells ?table {:alignment ?alignment}) => ?aligned-table)
-  ?table ?alignment ?aligned-table
-  table :right right-aligned-table
-  table :left left-aligned-table
-  table :center centered-table)
+(facts "about calculating padding values"
+       (tabular (fact "determines the paddings for the supplied table according to the alignment options"
+                      (formatter/paddings-for-cells ?table {:alignment ?alignment}) => ?aligned-table)
+                ?table ?alignment ?aligned-table
+                table :right right-aligned-table
+                table :left left-aligned-table
+                table :center centered-table))
 
 (def basic-tabular
   "(tabular (fact \"about basic arithmetic operations\"
@@ -115,14 +117,14 @@
 (defn throws-match [matcher]
   (throws clojure.lang.ExceptionInfo #(matcher-combinators/match? (matcher-combinators/match matcher (ex-data %)))))
 
-(tabular (fact "formats the tabular fact according to default options"
-               (formatter/format-tabular ?tabular)
-               => ?result)
-         ?tabular ?result
-         basic-tabular right-aligned-basic-tabular
-         basic-tabular-w-deliniated-header right-aligned-basic-tabular-w-deliniated-header
-         just-a-fact (throws-match {:type ::formatter/no-tabular})
-         just-a-vector (throws-match {:type ::formatter/no-tabular})
-         tabular-with-no-headers (throws-match {:type ::formatter/no-table-headers})
-         malformed-tabular (throws-match {:type ::formatter/malformed-table})
-         )
+(facts "about aligning tabular forms"
+       (tabular (fact "formats the tabular fact according to default options"
+                      (formatter/format-tabular ?tabular)
+                      => ?result)
+                ?tabular ?result
+                basic-tabular right-aligned-basic-tabular
+                basic-tabular-w-deliniated-header right-aligned-basic-tabular-w-deliniated-header
+                just-a-fact (throws-match {:type ::formatter/no-tabular})
+                just-a-vector (throws-match {:type ::formatter/no-tabular})
+                tabular-with-no-headers (throws-match {:type ::formatter/no-table-headers})
+                malformed-tabular (throws-match {:type ::formatter/malformed-table})))

--- a/test/midje_nrepl/middleware/test_info_test.clj
+++ b/test/midje_nrepl/middleware/test_info_test.clj
@@ -22,7 +22,7 @@
                                           :test-paths ["test"]})
              => irrelevant
              (provided
-              (project-info/get-test-namespaces-in ["test"]) => ['octocat.arithmetic-test 'octocat.colls-test]
+              (project-info/find-namespaces-in ["test"]) => ['octocat.arithmetic-test 'octocat.colls-test]
               (transport/send ..transport.. (match {:test-namespaces ["octocat.arithmetic-test" "octocat.colls-test"]})) => irrelevant
               (transport/send ..transport.. (match {:status #{:done}})) => irrelevant))
 
@@ -33,6 +33,6 @@ returns a list of all known test namespaces"
              => irrelevant
              (provided
               (project-info/get-test-paths) => ["src/clojure/test" "test"]
-              (project-info/get-test-namespaces-in ["src/clojure/test" "test"]) => ['octocat.arithmetic-test 'octocat.colls-test 'octocat.mocks-test]
+              (project-info/find-namespaces-in ["src/clojure/test" "test"]) => ['octocat.arithmetic-test 'octocat.colls-test 'octocat.mocks-test]
               (transport/send ..transport.. (match {:test-namespaces ["octocat.arithmetic-test" "octocat.colls-test" "octocat.mocks-test"]})) => irrelevant
               (transport/send ..transport.. (match {:status #{:done}})) => irrelevant)))

--- a/test/midje_nrepl/middleware/test_test.clj
+++ b/test/midje_nrepl/middleware/test_test.clj
@@ -42,14 +42,14 @@
               (transport/send ..transport.. transformed-report) => irrelevant
               (transport/send ..transport.. (match {:status #{:done}})) => irrelevant))
 
-       (fact "clients can pass `exclusions` and/or `inclusions` to filter out namespaces where tests will be run"
-             (test/handle-test {:op         "midje-test-all"
-                                :exclusions "^integration\\.too-heavy"
-                                :inclusions "^integration"
-                                :transport  ..transport..}) => irrelevant
+       (fact "clients can pass `ns-exclusions` and/or `ns-inclusions` to filter out namespaces where tests will be run"
+             (test/handle-test {:op            "midje-test-all"
+                                :ns-exclusions ["^integration\\.too-heavy"]
+                                :ns-inclusions ["^integration"]
+                                :transport     ..transport..}) => irrelevant
              (provided
-              (test-runner/run-all-tests (match {:exclusions #(= (str %) "^integration\\.too-heavy")
-                                                 :inclusions                                 #(= (str %) "^integration")})) => test-report
+              (test-runner/run-all-tests (match {:ns-exclusions #(= (map str %) ["^integration\\.too-heavy"])
+                                                 :ns-inclusions #(= (map str %) ["^integration"])})) => test-report
               (transport/send ..transport.. transformed-report) => irrelevant
               (transport/send ..transport.. (match {:status #{:done}})) => irrelevant))
 

--- a/test/midje_nrepl/misc_test.clj
+++ b/test/midje_nrepl/misc_test.clj
@@ -1,6 +1,6 @@
 (ns midje-nrepl.misc-test
-  (:require [midje.sweet :refer :all]
-            [midje-nrepl.misc :as misc]))
+  (:require [midje-nrepl.misc :as misc]
+            [midje.sweet :refer :all]))
 
 (facts "about miscellaneous functions"
 
@@ -12,4 +12,13 @@
                 "refactor-nrepl"    true
                 "midje"    true
                 "amazonica"   false
-                "bouncycastle"   false))
+                "bouncycastle"   false)
+
+       (tabular (fact "parses options according to the provided parsers map;
+       removes keys that aren't declared in the parsers map"
+                      (misc/parse-options ?options ?parsers-map) => ?result)
+                ?options                                            ?parsers-map                        ?result
+                {:ns "octocat.arithmetic-test"}                                            {:ns symbol} {:ns 'octocat.arithmetic-test}
+                {:x "12" :y "true"} {:x #(Integer/parseInt %) :y #(Boolean/parseBoolean %)}                {:x 12 :y true}
+                {:test-paths ["test"]}                                  {:test-paths identity}         {:test-paths ["test"]}
+                {:ns "octocat.arithmetic-test"}                                         {:kind keyword}                             {}))

--- a/test/midje_nrepl/test_runner_test.clj
+++ b/test/midje_nrepl/test_runner_test.clj
@@ -213,7 +213,7 @@
              => (match {:results {}
                         :summary {:check 0 :ns 0}})
              (provided
-              (project-info/get-test-namespaces-in ["test/octocat"]) => ['octocat.no-tests]))
+              (project-info/find-namespaces-in ["test/octocat"]) => ['octocat.no-tests]))
 
        (fact "results of the last execution are kept in the current session"
              (test-runner/run-all-tests-in ["test/octocat"])

--- a/test/midje_nrepl/test_runner_test.clj
+++ b/test/midje_nrepl/test_runner_test.clj
@@ -215,23 +215,27 @@
              (provided
               (project-info/get-test-paths) => ["test/octocat"]))
 
-       (tabular (fact "one can use exclusions and inclusions to run only a subset of tests"
-                      (-> (test-runner/run-all-tests {:test-paths ["test/octocat"]
-                                                      :exclusions ?exclusions
-                                                      :inclusions ?inclusions})
+       (tabular (fact "`:ns-exclusions` and `:ns-inclusions` allow for users to
+              filter out the list of namespaces to be tested"
+                      (-> (test-runner/run-all-tests {:test-paths    ["test/octocat"]
+                                                      :ns-exclusions ?exclusions
+                                                      :ns-inclusions ?inclusions})
                           :results
                           keys)
                       => ?results)
-                ?exclusions   ?inclusions                                                                                    ?results
-                #"mocks"           nil                     (match (m/in-any-order ['octocat.arithmetic-test 'octocat.colls-test]))
-                nil #"arithmetic"                                                                  ['octocat.arithmetic-test]
-                #"^octocat"           nil                                                                                         nil
-                nil   #"^octocat" (match (m/in-any-order ['octocat.arithmetic-test 'octocat.colls-test 'octocat.mocks-test])))
+                ?exclusions             ?inclusions                                                                                    ?results
+                [#"mocks"]                     nil                     (match (m/in-any-order ['octocat.arithmetic-test 'octocat.colls-test]))
+                nil         [#"arithmetic"]                                                                  ['octocat.arithmetic-test]
+                [#"^octocat"]                     nil                                                                                         nil
+                nil           [#"^octocat"] (match (m/in-any-order ['octocat.arithmetic-test 'octocat.colls-test 'octocat.mocks-test]))
+                [#"coll" #"mock"]                     nil                                                                  ['octocat.arithmetic-test]
+                nil [#"^foo" #"arithmetic"]                                                                  ['octocat.arithmetic-test])
 
-       (fact "when both exclusions and inclusions are present, the former takes precedence over the later"
-             (test-runner/run-all-tests {:test-paths ["test/octocat"]
-                                         :exclusions #"arithmetic"
-                                         :inclusions #"arithmetic"})
+       (fact "when both `:ns-exclusions` and `:ns-inclusions` are present, the
+       former takes precedence over the later"
+             (test-runner/run-all-tests {:test-paths    ["test/octocat"]
+                                         :ns-exclusions [#"arithmetic"]
+                                         :ns-inclusions [#"arithmetic"]})
              => (match {:results empty?}))
 
        (fact "returns a report with no tests when there are no tests to be run"


### PR DESCRIPTION
As of this pull request the `wrap-test` middleware accepts two new options:
`:ns-inclusions` and `:ns-exclusions`. Both are sequences of strings representing valid regular
expressions to filter out namespaces to be tested.

In addition, I'm redesigning some internal aspects of the midje-nrepl runner to
facilitate upcoming features like built-in support for code coverage and basic profiling.