### PR TITLE
Add support for collecting (optional) profiling information about tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `wrap-test` middleware, `:ns-exclusions` and `:ns-inclusions`. Those options
   allow for clients to send lists of regexes to filter namespaces to be excluded
   or included from/to the test execution.
+  - [#13](https://github.com/nubank/midje-nrepl/pull/13): allow for clients to
+    collect profiling statistics about tests. By default, only the total time
+    taken by the test suite is returned. Clients can obtain more detailed
+    information by sending the parameter `profile?` in the request.
 
 ## [1.1.0] - 2018-12-19
 

--- a/src/midje_nrepl/middleware/test.clj
+++ b/src/midje_nrepl/middleware/test.clj
@@ -15,10 +15,11 @@
 
 (defn- test-all-reply [message]
   (let [strings->regexes #(map re-pattern %)
-        options          (misc/parse-options message {:test-paths    identity
-                                                      :ns-exclusions strings->regexes
-                                                      :ns-inclusions strings->regexes})
-        report ((profiler/profiling test-runner/run-all-tests) options)]
+        options          (misc/parse-options message {:ns-exclusions strings->regexes
+                                                      :ns-inclusions strings->regexes
+                                                      :profile? #(Boolean/parseBoolean %)
+                                                      :test-paths    identity})
+        report ((profiler/profile test-runner/run-all-tests) options)]
     (send-report message report)))
 
 (defn- test-ns-reply [{:keys [ns] :as message}]

--- a/src/midje_nrepl/middleware/test.clj
+++ b/src/midje_nrepl/middleware/test.clj
@@ -1,10 +1,10 @@
 (ns midje-nrepl.middleware.test
   (:require [cider.nrepl.middleware.stacktrace :as stacktrace]
-            [midje-nrepl.profiler :as profiler]
             [clojure.tools.nrepl.misc :refer [response-for]]
             [clojure.tools.nrepl.transport :as transport]
             [midje-nrepl.misc :as misc]
-            [midje-nrepl.test-runner :as test-runner]
+            [midje-nrepl.profiler :as profiler]
+            [midje-nrepl.runner :as runner]
             [orchard.misc :refer [transform-value]]))
 
 (defmethod transform-value java.time.Duration [duration]
@@ -17,28 +17,31 @@
   (let [strings->regexes #(map re-pattern %)
         options          (misc/parse-options message {:ns-exclusions strings->regexes
                                                       :ns-inclusions strings->regexes
-                                                      :profile? #(Boolean/parseBoolean %)
+                                                      :profile?      #(Boolean/parseBoolean %)
+                                                      :slowest-tests int
                                                       :test-paths    identity})
-        report ((profiler/profile test-runner/run-all-tests) options)]
+        report           ((profiler/profile runner/run-all-tests) options)]
     (send-report message report)))
 
-(defn- test-ns-reply [{:keys [ns] :as message}]
-  (let [namespace (symbol ns)
-        report    (test-runner/run-tests-in-ns namespace)]
+(defn- test-ns-reply [message]
+  (let [options (misc/parse-options message {:ns symbol})
+        report  ((profiler/profile runner/run-tests-in-ns) options)]
     (send-report message report)))
 
-(defn- test-reply [{:keys [ns line source] :or {line 1} :as message}]
-  (let [namespace (symbol ns)
-        report    (test-runner/run-test namespace source line)]
+(defn- test-reply [message]
+  (let [options (misc/parse-options message {:ns     symbol
+                                             :source identity
+                                             :line   int})
+        report  ((profiler/profile runner/run-test) options)]
     (send-report message report)))
 
 (defn- retest-reply [message]
-  (->> (test-runner/re-run-non-passing-tests)
+  (->> ((profiler/profile runner/re-run-non-passing-tests) {})
        (send-report message)))
 
 (defn- test-stacktrace-reply [{:keys [index ns print-fn transport] :as message}]
   (let [namespace (symbol ns)
-        exception (test-runner/get-exception-at namespace index)]
+        exception (runner/get-exception-at namespace index)]
     (if exception
       (doseq [cause (stacktrace/analyze-causes exception print-fn)]
         (transport/send transport (response-for message cause)))

--- a/src/midje_nrepl/misc.clj
+++ b/src/midje_nrepl/misc.clj
@@ -1,5 +1,6 @@
 (ns midje-nrepl.misc
-  (:require             [orchard.classpath :as classpath]))
+  (:require             [orchard.classpath :as classpath])
+  (:import (java.time Duration LocalDateTime)))
 
 (defn dependency-in-classpath?
   "Return true if a given dependency is in the project's classpath, or false otherwise."
@@ -9,3 +10,13 @@
          (map #(.getPath %))
          (some (partial re-find pattern))
          boolean)))
+
+(defn now
+  "Return a java.time.LocalDateTime object representing the current date and time."
+  []
+  (LocalDateTime/now))
+
+(defn duration-between
+  "Return a java.time.Duration object representing the duration between two temporal objects."
+  [start end]
+  (Duration/between start end))

--- a/src/midje_nrepl/misc.clj
+++ b/src/midje_nrepl/misc.clj
@@ -1,6 +1,6 @@
 (ns midje-nrepl.misc
-  (:require             [orchard.classpath :as classpath])
-  (:import (java.time Duration LocalDateTime)))
+  (:require [orchard.classpath :as classpath])
+  (:import (java.time Duration Instant)))
 
 (defn dependency-in-classpath?
   "Return true if a given dependency is in the project's classpath, or false otherwise."
@@ -20,13 +20,12 @@
   (reduce (fn [result [key parse-fn]]
             (if-let [value (get options key)]
               (assoc result key (parse-fn value))
-              result)
-            ) {} parsers-map))
+              result)) {} parsers-map))
 
 (defn now
-  "Return a java.time.LocalDateTime object representing the current date and time."
+  "Return a java.time.Instant object representing the current instant."
   []
-  (LocalDateTime/now))
+  (Instant/now))
 
 (defn duration-between
   "Return a java.time.Duration object representing the duration between two temporal objects."

--- a/src/midje_nrepl/nrepl.clj
+++ b/src/midje_nrepl/nrepl.clj
@@ -51,10 +51,9 @@
      (set-descriptor! (var ~name) ~descriptor)))
 
 (defmiddleware wrap-format
-  {:expects  #{}
-   :requires #{}
-   :handles  {"midje-format-tabular"
-              {:requires {"code" "The tabular sexpr to be formatted"}}}}
+  {:handles {"midje-format-tabular"
+             {:doc      "Formats tabular facts."
+              :requires {"code" "The tabular sexpr to be formatted."}}}}
   'midje-nrepl.middleware.format/handle-format)
 
 (defn middleware-vars-expected-by-wrap-inhibit-tests []
@@ -68,39 +67,42 @@
   {:expects (middleware-vars-expected-by-wrap-inhibit-tests)
    :handles
    {"eval"
-    {:doc      "Delegates to `interruptible-eval` middleware, by preventing Midje facts from being run"
+    {:doc      "Delegates to `interruptible-eval` middleware, by preventing Midje facts from being run."
      :optional {"load-tests?" "If set to \"true\" any Midje fact loaded in the current operation will be run automatically (defaults to \"false\")."}}
     "warm-ast-cache"
-    {:doc      "Delegates to `refactor-nrepl.middleware/wrap-refactor` middleware, by preventing Midje facts from being run"
+    {:doc      "Delegates to `refactor-nrepl.middleware/wrap-refactor` middleware, by preventing Midje facts from being run."
      :optional {"load-tests?" "If set to \"true\" any Midje fact loaded in the current operation will be run automatically (defaults to \"false\")."}}
     "refresh"
-    {:doc      "Delegates to `cider.nrepl/wrap-refresh` by preventing Midje facts from being run"
+    {:doc      "Delegates to `cider.nrepl/wrap-refresh` by preventing Midje facts from being run."
      :optional {"load-tests?" "If set to \"true\" any Midje fact loaded in the current operation will be run automatically (defaults to \"false\")."}}
     "refresh-all"
-    {:doc      "Delegates to `cider.nrepl/wrap-refresh` by preventing Midje facts from being run"
+    {:doc      "Delegates to `cider.nrepl/wrap-refresh` by preventing Midje facts from being run."
      :optional {"load-tests?" "If set to \"true\" any Midje fact loaded in the current operation will be run automatically (defaults to \"false\")."}}}}
   'midje-nrepl.middleware.inhibit-tests/handle-inhibit-tests)
+
 (defmiddleware wrap-test
-  {:expects  #{}
-   :requires #{}
-   :handles  {"midje-test-all"
-              {:doc "Runs all Midje tests in the project"}
-              "midje-test-ns"
-              {:doc      "Runs all Midje tests in the namespace."
-               :requires {"ns" "A string indicating the namespace containing the tests to be run."}}
-              "midje-test"
-              {:doc      "Runs a given Midje test (either an individual fact or facts)."
-               :requires {"ns"     "The namespace in which the fact(s) sent through `test-forms` should be evaluated."
-                          "source" "The fact(s) to be run."}
-               :optional
-               {"line" "The line number where the facts to be tested starts."}}
-              "midje-retest"
-              {:doc "Re-runs the tests that didn't pass in the last execution."}
-              "midje-test-stacktrace"
-              {:doc      "Returns the stacktrace of a given erring test. Returns the status `no-stacktrace` if there is no stacktrace for the specified test."
-               :requires {"ns"       "A string indicating the namespace of the erring test."
-                          "index"    "An integer indicating the index of the erring test in question."
-                          "print-fn" "Fully qualified name of a print function that will be used to print stacktraces."}}}}
+  {:handles {"midje-test-all"
+             {:doc      "Runs all Midje tests defined in the project."
+              :optional {"ns-exclusions" "A list of regexes to match namespaces against. Matched namespaces will be excluded from the tests."
+                         "ns-inclusions" "A list of regexes to match namespaces against. Only matched namespaces will be included in the tests."
+                         "profile?"      "A boolean indicating whether the middleware should collect profiling information about tests. Defaults to false."
+                         "test-paths"    "A list of test directories to find tests in. Defaults to all known test directories in the current project."}}
+             "midje-test-ns"
+             {:doc      "Runs all Midje tests defined in the namespace."
+              :requires {"ns" "A string indicating the namespace containing the tests to be run."}}
+             "midje-test"
+             {:doc      "Runs only the supplied Midje test (either an individual fact or facts)."
+              :requires {"ns"     "The namespace in which the fact(s) sent through `source` should be evaluated."
+                         "source" "The fact(s) to be run."}
+              :optional
+              {"line" "The line number where the facts to be tested starts."}}
+             "midje-retest"
+             {:doc "Re-runs the tests that didn't pass in the last execution."}
+             "midje-test-stacktrace"
+             {:doc      "Returns the stacktrace of a given erring test. Returns the status `no-stacktrace` if there is no stacktrace for the specified test."
+              :requires {"ns"       "A string indicating the namespace of the erring test."
+                         "index"    "An integer indicating the index of the erring test in question."
+                         "print-fn" "Fully qualified name of a print function that will be used to print stacktraces."}}}}
   'midje-nrepl.middleware.test/handle-test)
 
 (defmiddleware wrap-test-info
@@ -108,15 +110,12 @@
              {:doc "Returns a list of known test paths for the current project."}
              "test-namespaces"
              {:doc      "Returns a list of test namespaces declared within specified test paths."
-              :optional {"test-paths" "A list of test paths to find namespaces
-  in. If omitted find namespaces in all known test paths."}}}}
+              :optional {"test-paths" "A list of test paths to find namespaces in. If omitted find namespaces in all known test paths."}}}}
   'midje-nrepl.middleware.test-info/handle-test-info)
 
 (defmiddleware wrap-version
-  {:expects  #{}
-   :requires #{}
-   :handles  {"midje-nrepl-version"
-              {:doc "Provides information about midje-nrepl's current version."}}}
+  {:handles {"midje-nrepl-version"
+             {:doc "Provides information about midje-nrepl's current version."}}}
   'midje-nrepl.middleware.version/handle-version)
 
 (def middleware `[wrap-format

--- a/src/midje_nrepl/profiler.clj
+++ b/src/midje_nrepl/profiler.clj
@@ -41,3 +41,13 @@
        (map (fn [{:keys [started-at finished-at] :as result}]
               (assoc (select-keys result [:context :file :line])
                      :duration (misc/duration-between started-at finished-at))))))
+
+(defn duration->string
+  "Returns a friendly representation of the duration object in question."
+  [duration]
+  (let [milliseconds (.toMillis duration)]
+    (cond
+      (<= milliseconds 1000)  (str milliseconds " milliseconds")
+      (<= milliseconds 60000) (format "%.2f seconds" (/ milliseconds 1000.0))
+      :else                   (format "%.2f minutes" (/ milliseconds
+                                                        60000.0)))))

--- a/src/midje_nrepl/profiler.clj
+++ b/src/midje_nrepl/profiler.clj
@@ -52,7 +52,9 @@
 (defn average
   "Returns the average time taken by each test in the test suite."
   [total-time number-of-tests]
-  (.dividedBy total-time number-of-tests))
+  (if (zero? number-of-tests)
+    (Duration/ZERO)
+    (.dividedBy total-time number-of-tests)))
 
 (defn- stats-for-ns [ns test-results total-time-of-suite]
   (let [number-of-tests (count test-results)]

--- a/src/midje_nrepl/profiler.clj
+++ b/src/midje_nrepl/profiler.clj
@@ -1,6 +1,16 @@
 (ns midje-nrepl.profiler
   (:require [midje-nrepl.misc :as misc]))
 
+(defn duration->string
+  "Returns a friendly representation of the duration object in question."
+  [duration]
+  (let [milliseconds (.toMillis duration)]
+    (cond
+      (<= milliseconds 1000)  (str milliseconds " milliseconds")
+      (<= milliseconds 60000) (format "%.2f seconds" (/ milliseconds 1000.0))
+      :else                   (format "%.2f minutes" (/ milliseconds
+                                                        60000.0)))))
+
 (defn- duration-of-tests-in-ns [test-results]
   (let [{:keys [started-at]}  (first test-results)
         {:keys [finished-at]} (last test-results)]
@@ -20,34 +30,41 @@
        (map #(update % 1 duration-of-tests-in-ns))
        (map (partial zipmap [:ns :duration]))))
 
-(defn- slowest-test-comparator
-  "Compare two test results and determine the slowest of them."
+(defn- fastest-test-comparator
+  "Compares two test results and determines the fastest one."
   [x y]
   (letfn [(test-duration [{:keys [started-at finished-at]}]
             (misc/duration-between started-at finished-at))]
-    (* -1
-       (.compareTo (test-duration x) (test-duration y)))))
+    (.compareTo (test-duration x) (test-duration y))))
 
-(defn top-slowest-tests
-  "Returns the top n slowest tests in the report map."
-  [n report-map]
+(def ^:private slowest-test-comparator
+  "Compares two test results and determines the slowest one."
+  (comp (partial * -1) fastest-test-comparator))
+
+(defn- top-tests
+  "Returns the top n fastest or slowest tests (depending upon the supplied comparator) in the report map."
+  [comparator n report-map]
   (->> report-map
        :results
        vals
        flatten
        keep-distinct-tests-with-known-durations
-       (sort slowest-test-comparator)
+       (sort comparator)
        (take n)
        (map (fn [{:keys [started-at finished-at] :as result}]
               (assoc (select-keys result [:context :file :line])
                      :duration (misc/duration-between started-at finished-at))))))
 
-(defn duration->string
-  "Returns a friendly representation of the duration object in question."
-  [duration]
-  (let [milliseconds (.toMillis duration)]
-    (cond
-      (<= milliseconds 1000)  (str milliseconds " milliseconds")
-      (<= milliseconds 60000) (format "%.2f seconds" (/ milliseconds 1000.0))
-      :else                   (format "%.2f minutes" (/ milliseconds
-                                                        60000.0)))))
+(def top-fastest-tests
+  "Returns the top n fastest tests in the report map."
+  (partial top-tests fastest-test-comparator))
+
+(def top-slowest-tests
+  "Returns the top n slowest tests in the report map."
+  (partial top-tests slowest-test-comparator))
+
+(defn average
+  "Returns a map describing the average of the duration of tests."
+  [duration number-of-tests]
+  {:duration (.dividedBy duration number-of-tests)
+   :tests    number-of-tests})

--- a/src/midje_nrepl/profiler.clj
+++ b/src/midje_nrepl/profiler.clj
@@ -11,25 +11,6 @@
       :else                   (format "%.2f minutes" (/ milliseconds
                                                         60000.0)))))
 
-(defn- duration-of-tests-in-ns [test-results]
-  (let [{:keys [started-at]}  (first test-results)
-        {:keys [finished-at]} (last test-results)]
-    (misc/duration-between started-at finished-at)))
-
-(defn- keep-distinct-tests-with-known-durations [test-results]
-  (->> test-results
-       (filter #(and (:started-at %)
-                     (:finished-at %)))
-       (group-by :id)
-       vals
-       (map last)))
-
-(defn duration-per-namespace [report-map]
-  (->> report-map
-       :results
-       (map #(update % 1 duration-of-tests-in-ns))
-       (map (partial zipmap [:ns :duration]))))
-
 (defn- fastest-test-comparator
   "Compares two test results and determines the fastest one."
   [x y]
@@ -42,13 +23,9 @@
   (comp (partial * -1) fastest-test-comparator))
 
 (defn- top-tests
-  "Returns the top n fastest or slowest tests (depending upon the supplied comparator) in the report map."
-  [comparator n report-map]
-  (->> report-map
-       :results
-       vals
-       flatten
-       keep-distinct-tests-with-known-durations
+  "Returns the top n fastest or slowest tests (depending upon the supplied comparator)."
+  [comparator n test-results]
+  (->> test-results
        (sort comparator)
        (take n)
        (map (fn [{:keys [started-at finished-at] :as result}]
@@ -56,15 +33,57 @@
                      :duration (misc/duration-between started-at finished-at))))))
 
 (def top-fastest-tests
-  "Returns the top n fastest tests in the report map."
+  "Returns the top n fastest tests in the test results."
   (partial top-tests fastest-test-comparator))
 
 (def top-slowest-tests
-  "Returns the top n slowest tests in the report map."
+  "Returns the top n slowest tests in the test results."
   (partial top-tests slowest-test-comparator))
+
+(defn- duration-of-tests-in-ns [test-results]
+  (let [{:keys [started-at]}  (first test-results)
+        {:keys [finished-at]} (last test-results)]
+    (misc/duration-between started-at finished-at)))
+
+(defn duration-per-ns [test-results]
+  (->> test-results
+       (group-by :ns)
+       (map #(update % 1 duration-of-tests-in-ns))
+       (into {})))
 
 (defn average
   "Returns a map describing the average of the duration of tests."
   [duration number-of-tests]
   {:duration (.dividedBy duration number-of-tests)
    :tests    number-of-tests})
+
+(defn distinct-results-with-known-durations [report-map]
+  (->> report-map
+       :results
+       vals
+       flatten
+       (filter #(and (:started-at %)
+                     (:finished-at %)))
+       (group-by :id)
+       vals
+       (map last)))
+
+(defn- assoc-stats [report-map options]
+  (let [{:keys [fastest-tests slowest-tests]
+         :or   {fastest-tests 1
+                slowest-tests 1}} options
+        test-results              (distinct-results-with-known-durations report-map)]
+    (assoc report-map
+           :profiling {:average         (average (get-in report-map [:summary :finished-in]) (count test-results))
+                       :duration-per-ns (duration-per-ns test-results)
+                       :fastest-tests   (top-fastest-tests fastest-tests test-results)
+                       :slowest-tests   (top-slowest-tests slowest-tests test-results)})))
+
+(defn profiling [runner]
+  (fn [options]
+    (let [start      (misc/now)
+          report-map (runner options)
+          end        (misc/now)]
+      (-> report-map
+          (assoc-in [:summary :finished-in] (misc/duration-between start end))
+          (assoc-stats options)))))

--- a/src/midje_nrepl/profiler.clj
+++ b/src/midje_nrepl/profiler.clj
@@ -41,10 +41,10 @@
   [test-results total-time]
   (let [total-time-of-group   (reduce (fn [total {:keys [total-time]}]
                                         (.plus total total-time)) (Duration/ZERO) test-results)
-        percent-of-total-time (/ (.. total-time-of-group (multipliedBy 100) toMillis)
-                                 (.toMillis total-time))]
+        percent-of-total-time (float (/ (.. total-time-of-group (multipliedBy 100) toMillis)
+                                        (.toMillis total-time)))]
     {:total-time            total-time-of-group
-     :percent-of-total-time (format "%.2f%%" (double percent-of-total-time))}))
+     :percent-of-total-time (str (.format formatter percent-of-total-time) "%")}))
 
 (defn average
   "Returns the average time taken by each test in the test suite."
@@ -105,5 +105,6 @@
           end        (misc/now)]
       (-> report-map
           (assoc-in [:summary :finished-in] (misc/duration-between start end))
-          (cond-> profile?
+          (cond-> (and profile?
+                       (not (zero? (get-in report-map [:summary :check]))))
             (assoc-stats options))))))

--- a/src/midje_nrepl/profiler.clj
+++ b/src/midje_nrepl/profiler.clj
@@ -6,11 +6,34 @@
         {:keys [finished-at]} (last test-results)]
     (misc/duration-between started-at finished-at)))
 
+(defn- keep-only-tests-with-a-known-duration [test-results]
+  (filter #(and (:started-at %)
+                (:finished-at %)) test-results))
+
 (defn duration-per-namespace [report-map]
   (->> report-map
        :results
        (map #(update % 1 duration-of-tests-in-ns))
        (map (partial zipmap [:ns :duration]))))
 
-(defn top-slowest-tests [report-map n]
-  )
+(defn- slowest-test-comparator
+  "Compare two test results and determine the slowest of them."
+  [x y]
+  (letfn [(test-duration [{:keys [started-at finished-at]}]
+            (misc/duration-between started-at finished-at))]
+    (* -1
+       (.compareTo (test-duration x) (test-duration y)))))
+
+(defn top-slowest-tests
+  "Return the top n slowest tests in the report map."
+  [n report-map]
+  (->> report-map
+       :results
+       vals
+       flatten
+       keep-only-tests-with-a-known-duration
+       (sort slowest-test-comparator)
+       (take n)
+       (map (fn [{:keys [started-at finished-at] :as result}]
+              (assoc (select-keys result [:context :file :line])
+                     :duration (misc/duration-between started-at finished-at))))))

--- a/src/midje_nrepl/profiler.clj
+++ b/src/midje_nrepl/profiler.clj
@@ -1,5 +1,6 @@
 (ns midje-nrepl.profiler
-  (:require [midje-nrepl.misc :as misc]))
+  (:require [midje-nrepl.misc :as misc])
+  (:import (java.time Duration)))
 
 (defn duration->string
   "Returns a friendly representation of the duration object in question."
@@ -54,7 +55,9 @@
 (defn average
   "Returns a map describing the average of the duration of tests."
   [duration number-of-tests]
-  {:duration (.dividedBy duration number-of-tests)
+  {:duration (if (zero? number-of-tests)
+               (Duration/ZERO)
+               (.dividedBy duration number-of-tests))
    :tests    number-of-tests})
 
 (defn distinct-results-with-known-durations [report-map]

--- a/src/midje_nrepl/profiler.clj
+++ b/src/midje_nrepl/profiler.clj
@@ -1,0 +1,16 @@
+(ns midje-nrepl.profiler
+  (:require [midje-nrepl.misc :as misc]))
+
+(defn- duration-of-tests-in-ns [test-results]
+  (let [{:keys [started-at]}  (first test-results)
+        {:keys [finished-at]} (last test-results)]
+    (misc/duration-between started-at finished-at)))
+
+(defn duration-per-namespace [report-map]
+  (->> report-map
+       :results
+       (map #(update % 1 duration-of-tests-in-ns))
+       (map (partial zipmap [:ns :duration]))))
+
+(defn top-slowest-tests [report-map n]
+  )

--- a/src/midje_nrepl/profiler.clj
+++ b/src/midje_nrepl/profiler.clj
@@ -28,10 +28,10 @@
 (defn time-consumption
   "Returns statistics about the time taken by the supplied test results."
   [test-results total-time]
-  (let [total-time-of-group (reduce (fn [total {:keys [total-time]}]
-                                      (.plus total total-time)) (Duration/ZERO) test-results)
-        percent-of-total-time       (/ (.. total-time-of-group (multipliedBy 100) toMillis)
-                                       (.toMillis total-time))]
+  (let [total-time-of-group   (reduce (fn [total {:keys [total-time]}]
+                                        (.plus total total-time)) (Duration/ZERO) test-results)
+        percent-of-total-time (/ (.. total-time-of-group (multipliedBy 100) toMillis)
+                                 (.toMillis total-time))]
     {:total-time            total-time-of-group
      :percent-of-total-time (format "%.2f%%" (double percent-of-total-time))}))
 

--- a/src/midje_nrepl/profiler.clj
+++ b/src/midje_nrepl/profiler.clj
@@ -83,10 +83,11 @@
                        :slowest-tests   (top-slowest-tests slowest-tests test-results)})))
 
 (defn profiling [runner]
-  (fn [options]
+  (fn [{:keys [profiling?] :as options}]
     (let [start      (misc/now)
           report-map (runner options)
           end        (misc/now)]
       (-> report-map
           (assoc-in [:summary :finished-in] (misc/duration-between start end))
-          (assoc-stats options)))))
+          (cond-> profiling?
+            (assoc-stats options))))))

--- a/test/midje_nrepl/middleware/test_test.clj
+++ b/test/midje_nrepl/middleware/test_test.clj
@@ -21,7 +21,7 @@
                      :type     :fail}]}
                   :summary {:check 1 :error 0 :fact 1 :fail 1 :ns 1 :pass 0 :to-do 0}})
 
-(def transformed-report (assoc-in (transform-value test-report) ["summary" "finished-in"] "1 milliseconds"))
+(def transformed-report (assoc-in (transform-value test-report) ["summary" "finished-in"] "1 millisecond"))
 
 (def exception (RuntimeException. "An unexpected error was thrown" (ArithmeticException. "Divid by zero")))
 

--- a/test/midje_nrepl/middleware/test_test.clj
+++ b/test/midje_nrepl/middleware/test_test.clj
@@ -18,7 +18,9 @@
                      :expected 6
                      :actual   5
                      :message  '()
-                     :type     :fail}]}
+                     :type     :fail
+                     :started-at (misc/now)
+                     :finished-at (misc/now)}]}
                   :summary {:check 1 :error 0 :fact 1 :fail 1 :ns 1 :pass 0 :to-do 0}})
 
 (def transformed-report (assoc-in (transform-value test-report) ["summary" "finished-in"] "1 millisecond"))

--- a/test/midje_nrepl/misc_test.clj
+++ b/test/midje_nrepl/misc_test.clj
@@ -1,6 +1,7 @@
 (ns midje-nrepl.misc-test
-  (:require [midje.sweet :refer :all]
-            [midje-nrepl.misc :as misc]))
+  (:require [midje-nrepl.misc :as misc]
+            [midje.sweet :refer :all])
+  (:import [java.time Duration LocalDateTime]))
 
 (facts "about miscellaneous functions"
 
@@ -12,4 +13,12 @@
                 "refactor-nrepl"    true
                 "midje"    true
                 "amazonica"   false
-                "bouncycastle"   false))
+                "bouncycastle"   false)
+
+       (fact "returns a `java.time.LocalDateTime` representing the current date and time"
+             (misc/now)
+             => #(instance? LocalDateTime %))
+
+       (fact "returns a `java.time.Duration` representing the duration between the two temporal objects"
+             (misc/duration-between (misc/now) (misc/now))
+             => #(instance? Duration %)))

--- a/test/midje_nrepl/misc_test.clj
+++ b/test/midje_nrepl/misc_test.clj
@@ -1,7 +1,7 @@
 (ns midje-nrepl.misc-test
   (:require [midje-nrepl.misc :as misc]
             [midje.sweet :refer :all])
-  (:import [java.time Duration LocalDateTime]))
+  (:import [java.time Duration Instant]))
 
 (facts "about miscellaneous functions"
 
@@ -24,9 +24,9 @@
                 {:test-paths ["test"]}                                  {:test-paths identity}         {:test-paths ["test"]}
                 {:ns "octocat.arithmetic-test"}                                         {:kind keyword}                             {})
 
-       (fact "returns a `java.time.LocalDateTime` representing the current date and time"
+       (fact "returns a `java.time.Instant` representing the current instant"
              (misc/now)
-             => #(instance? LocalDateTime %))
+             => #(instance? Instant %))
 
        (fact "returns a `java.time.Duration` representing the duration between the two temporal objects"
              (misc/duration-between (misc/now) (misc/now))

--- a/test/midje_nrepl/profiler_test.clj
+++ b/test/midje_nrepl/profiler_test.clj
@@ -104,11 +104,15 @@
 (facts "about the profiler"
 
        (tabular (fact "returns a friendly string representing the duration in question"
-                      (profiler/duration->string ?duration) => ?result)
-                ?duration            ?result
-                (Duration/ofMillis 256) "256 milliseconds"
-                (Duration/ofMillis 6537)     "6.54 seconds"
-                (Duration/ofMinutes 4)     "4.00 minutes")
+                             (profiler/duration->string ?duration) => ?result)
+                         ?duration            ?result
+             (Duration/ofMillis 1)    "1 millisecond"
+           (Duration/ofMillis 256) "256 milliseconds"
+          (Duration/ofMillis 1000)         "1 second"
+          (Duration/ofMillis 6537)     "6.54 seconds"
+            (Duration/ofMinutes 1)         "1 minute"
+         (Duration/ofMillis 63885)     "1.06 minutes"
+            (Duration/ofMinutes 4)        "4 minutes")
 
        (fact "given the total time of the test suite and the number of tests in
        that suite, returns the average time taken by each test"

--- a/test/midje_nrepl/profiler_test.clj
+++ b/test/midje_nrepl/profiler_test.clj
@@ -1,31 +1,32 @@
 (ns midje-nrepl.profiler-test
   (:require [clojure.java.io :as io]
+            [matcher-combinators.midje :refer [match]]
             [midje-nrepl.misc :as misc]
             [midje-nrepl.profiler :as profiler]
             [midje.sweet :refer :all])
   (:import [java.time Duration LocalDateTime]))
 
-(defn local-date-time [seconds]
-  (LocalDateTime/of 2019 01 01 12 0 seconds))
+(defn local-date-time [millis]
+  (LocalDateTime/of 2019 01 01 12 0 0 millis))
 
-(defn plus-seconds [time seconds]
-  (.plusSeconds time seconds))
+(defn plus-millis [time millis]
+  (.plusNanos time (* millis 1000000)))
 
 (def start-point (local-date-time 0))
 
-(def one-second-later (plus-seconds start-point 1))
+(def one-millisecond-later (plus-millis start-point 1))
 
-(def two-seconds-later (plus-seconds start-point 2))
+(def two-milliseconds-later (plus-millis start-point 2))
 
-(def three-seconds-later (plus-seconds start-point 3))
+(def three-milliseconds-later (plus-millis start-point 3))
 
-(def three-seconds+one-millisecond-later (.plusNanos three-seconds-later 1000000))
+(def three-and-half-milliseconds-later (.plusNanos three-milliseconds-later 500000))
 
-(def nine-and-half-seconds-later (plus-seconds start-point 9.5))
+(def nine-milliseconds-later (plus-millis start-point 9))
 
-(def ten-seconds-later (plus-seconds start-point 10))
+(def ten-milliseconds-later (plus-millis start-point 10))
 
-(def thirteen-seconds-later (plus-seconds start-point 13))
+(def thirteen-milliseconds-later (plus-millis start-point 13))
 
 (def arithmetic-test-file (io/file "/home/john-doe/projects/octocat/test/octocat/arithmetic_test.clj"))
 
@@ -34,51 +35,69 @@
 (def report-map {:results
                  {'octocat.arithmetic-test [{:context     ["First arithmetic test"]
                                              :id          "20208edc-4129-4511-be13-38c9a8e28480"
+                                             :ns 'octocat.arithmetic-test
                                              :file        arithmetic-test-file
                                              :line        5
                                              :started-at  start-point
-                                             :finished-at one-second-later}
+                                             :finished-at one-millisecond-later}
                                             {:context ["I am a future fact"]}
                                             {:context     ["second arithmetic test"]
                                              :id          "021a8d7f-e546-42e4-8c70-da4fcc7be6b4"
+                                             :ns 'octocat.arithmetic-test
                                              :file        arithmetic-test-file
                                              :line        8
-                                             :started-at  one-second-later
-                                             :finished-at two-seconds-later}
+                                             :started-at  one-millisecond-later
+                                             :finished-at two-milliseconds-later}
                                             {:context     ["third arithmetic test"]
                                              :id          "b64ac1c8-ff83-4785-8cec-9c180609cb9f"
+                                             :ns 'octocat.arithmetic-test
                                              :file        arithmetic-test-file
                                              :line        10
-                                             :started-at  two-seconds-later
-                                             :finished-at three-seconds-later}
+                                             :started-at  two-milliseconds-later
+                                             :finished-at three-milliseconds-later}
                                             {:context     ["fourth arithmetic test"]
                                              :id          "a3d7e905-8f3f-40b2-bf80-a80566a90a64"
+                                             :ns 'octocat.arithmetic-test
                                              :file        arithmetic-test-file
                                              :line        13
-                                             :started-at  three-seconds-later
-                                             :finished-at three-seconds+one-millisecond-later}]
+                                             :started-at  three-milliseconds-later
+                                             :finished-at three-and-half-milliseconds-later}]
                   'octocat.heavy-test      [{:context     ["First heavy test"]
                                              :id          "8a8e79c5-84aa-4846-b233-5969ec26a853"
+                                             :ns 'octocat.heavy-test
                                              :file        heavy-test-file
                                              :line        5
-                                             :started-at  three-seconds-later
-                                             :finished-at nine-and-half-seconds-later}
+                                             :started-at  three-milliseconds-later
+                                             :finished-at nine-milliseconds-later}
                                             {:context     ["First heavy test"]
                                              :id          "8a8e79c5-84aa-4846-b233-5969ec26a853"
+                                             :ns 'octocat.heavy-test
                                              :file        heavy-test-file
                                              :line        7
-                                             :started-at  three-seconds-later
-                                             :finished-at ten-seconds-later}
+                                             :started-at  three-milliseconds-later
+                                             :finished-at ten-milliseconds-later}
                                             {:context ["I don't have a duration"]
-                                             :id      "0f9878b3-4d28-484d-9b98-a61ef53f4f89"}
+                                             :id      "0f9878b3-4d28-484d-9b98-a61ef53f4f89"
+                                             :ns 'octocat.heavy-test}
                                             {:context ["I don't have a duration too"]
-                                             :id      "2f965b08-3508-43df-969b-274a0a360009"}
+                                             :id      "2f965b08-3508-43df-969b-274a0a360009"
+                                             :ns 'octocat.heavy-test}
                                             {:context     ["second heavy test"]
                                              :id          "12160c1a-4d4a-4d8d-8870-72243ee9539e"
+                                             :ns 'octocat.heavy-test
                                              :file        heavy-test-file
                                              :line        12
-                                             :started-at  ten-seconds-later
-                                             :finished-at thirteen-seconds-later}]}})
+                                             :started-at  ten-milliseconds-later
+                                             :finished-at thirteen-milliseconds-later}]}
+                 :summary {:check 6 :error 0 :fail 0 :ns 2 :pass 6 :to-do 3}})
+
+(def test-results (profiler/distinct-results-with-known-durations report-map))
+
+(defn fake-runner [_]
+  (Thread/sleep (.toMillis (misc/duration-between start-point thirteen-milliseconds-later)))
+  report-map)
+
+(def duration? #(instance? Duration %))
 
 (facts "about the profiler"
 
@@ -90,41 +109,53 @@
                 (Duration/ofMinutes 4)     "4.00 minutes")
 
        (fact "computes the duration of tests for each namespace"
+             (profiler/duration-per-ns test-results)
+             => {'octocat.arithmetic-test  (misc/duration-between start-point three-and-half-milliseconds-later)
+                 'octocat.heavy-test (misc/duration-between three-milliseconds-later thirteen-milliseconds-later)})
 
-             (profiler/duration-per-namespace report-map)
-             => [{:ns       'octocat.arithmetic-test
-                  :duration (misc/duration-between start-point three-seconds+one-millisecond-later)}
-                 {:ns       'octocat.heavy-test
-                  :duration (misc/duration-between three-seconds-later thirteen-seconds-later)}])
-
-       (fact "returns information about the fastest test in the report map"
-             (profiler/top-fastest-tests 1 report-map)
+       (fact "returns information about the fastest test in the test results"
+             (profiler/top-fastest-tests 1 test-results)
              => [{:context  ["fourth arithmetic test"]
                   :file     arithmetic-test-file
                   :line     13
-                  :duration (misc/duration-between three-seconds-later three-seconds+one-millisecond-later)}])
+                  :duration (misc/duration-between three-milliseconds-later three-and-half-milliseconds-later)}])
 
-       (fact "returns information about the slowest test in the report map"
-             (profiler/top-slowest-tests 1 report-map)
+       (fact "returns information about the slowest test in the test results"
+             (profiler/top-slowest-tests 1 test-results)
              => [{:context  ["First heavy test"]
                   :file     heavy-test-file
                   :line     7
-                  :duration (misc/duration-between three-seconds-later ten-seconds-later)}])
+                  :duration (misc/duration-between three-milliseconds-later ten-milliseconds-later)}])
 
-       (fact "returns information about the top n slowest tests in the report map"
-             (profiler/top-slowest-tests 2 report-map)
+       (fact "returns information about the top n slowest tests in the test results"
+             (profiler/top-slowest-tests 2 test-results)
              => [{:context  ["First heavy test"]
                   :file     heavy-test-file
                   :line     7
-                  :duration (misc/duration-between three-seconds-later ten-seconds-later)}
+                  :duration (misc/duration-between three-milliseconds-later ten-milliseconds-later)}
                  {:context  ["second heavy test"]
                   :file     heavy-test-file
                   :line     12
-                  :duration (misc/duration-between ten-seconds-later
-
-                                                   thirteen-seconds-later)}])
+                  :duration (misc/duration-between ten-milliseconds-later
+                                                   thirteen-milliseconds-later)}])
 
        (fact "calculates the average of the duration of tests according to the supplied information"
-             (profiler/average (misc/duration-between start-point ten-seconds-later) 10)
-             => {:duration (misc/duration-between start-point one-second-later)
-                 :tests 10}))
+             (profiler/average (misc/duration-between start-point ten-milliseconds-later) 10)
+             => {:duration (misc/duration-between start-point one-millisecond-later)
+                 :tests 10})
+
+       (fact ""
+             ((profiler/profiling fake-runner) {})
+             => (match {:profiling
+                        {:average {:duration duration?
+                                   :tests 6}
+                         :duration-per-ns {'octocat.arithmetic-test duration?
+                                           'octocat.heavy-test duration?}
+                         :fastest-tests [{:context  ["fourth arithmetic test"]
+                                          :line     13
+                                          :duration duration?}]
+                         :slowest-tests [{:context  ["First heavy test"]
+                                          :line     7
+                                          :duration duration?}]}
+                        :summary {:finished-in duration?}})
+             ))

--- a/test/midje_nrepl/profiler_test.clj
+++ b/test/midje_nrepl/profiler_test.clj
@@ -121,6 +121,10 @@
              (profiler/average (misc/duration-between start-point ten-milliseconds-later) 10)
              => (millis->duration 1))
 
+       (fact "when the number of tests is zero, returns a zeroed duration"
+             (profiler/average (Duration/ZERO) 0)
+             => (Duration/ZERO))
+
        (fact "produces profiling statistics for each namespace"
              (profiler/stats-per-ns test-results total-time)
              => [{:ns                    'octocat.heavy-test

--- a/test/midje_nrepl/profiler_test.clj
+++ b/test/midje_nrepl/profiler_test.clj
@@ -4,18 +4,15 @@
             [midje-nrepl.misc :as misc]
             [midje-nrepl.profiler :as profiler]
             [midje.sweet :refer :all])
-  (:import [java.time Duration LocalDateTime]))
+  (:import java.time.Duration))
 
-(defn local-date-time [millis]
-  (LocalDateTime/of 2019 01 01 12 0 0 millis))
-
-(defn plus-millis [time millis]
-  (.plusNanos time (* millis 1000000)))
+(defn plus-millis [instant millis]
+  (.plusMillis instant millis))
 
 (defn millis->duration [millis]
   (.plusNanos (Duration/ZERO) (* millis 1000000)))
 
-(def start-point (local-date-time 0))
+(def start-point (misc/now))
 
 (def one-millisecond-later (plus-millis start-point 1))
 

--- a/test/midje_nrepl/profiler_test.clj
+++ b/test/midje_nrepl/profiler_test.clj
@@ -12,6 +12,9 @@
 (defn plus-millis [time millis]
   (.plusNanos time (* millis 1000000)))
 
+(defn millis->duration [millis]
+  (.plusNanos (Duration/ZERO) (* millis 1000000)))
+
 (def start-point (local-date-time 0))
 
 (def one-millisecond-later (plus-millis start-point 1))
@@ -20,7 +23,7 @@
 
 (def three-milliseconds-later (plus-millis start-point 3))
 
-(def three-and-half-milliseconds-later (.plusNanos three-milliseconds-later 500000))
+(def four-milliseconds-later (plus-millis start-point 4))
 
 (def nine-milliseconds-later (plus-millis start-point 9))
 
@@ -35,7 +38,7 @@
 (def report-map {:results
                  {'octocat.arithmetic-test [{:context     ["First arithmetic test"]
                                              :id          "20208edc-4129-4511-be13-38c9a8e28480"
-                                             :ns 'octocat.arithmetic-test
+                                             :ns          'octocat.arithmetic-test
                                              :file        arithmetic-test-file
                                              :line        5
                                              :started-at  start-point
@@ -43,48 +46,48 @@
                                             {:context ["I am a future fact"]}
                                             {:context     ["second arithmetic test"]
                                              :id          "021a8d7f-e546-42e4-8c70-da4fcc7be6b4"
-                                             :ns 'octocat.arithmetic-test
+                                             :ns          'octocat.arithmetic-test
                                              :file        arithmetic-test-file
                                              :line        8
                                              :started-at  one-millisecond-later
                                              :finished-at two-milliseconds-later}
                                             {:context     ["third arithmetic test"]
                                              :id          "b64ac1c8-ff83-4785-8cec-9c180609cb9f"
-                                             :ns 'octocat.arithmetic-test
+                                             :ns          'octocat.arithmetic-test
                                              :file        arithmetic-test-file
                                              :line        10
                                              :started-at  two-milliseconds-later
                                              :finished-at three-milliseconds-later}
                                             {:context     ["fourth arithmetic test"]
                                              :id          "a3d7e905-8f3f-40b2-bf80-a80566a90a64"
-                                             :ns 'octocat.arithmetic-test
+                                             :ns          'octocat.arithmetic-test
                                              :file        arithmetic-test-file
                                              :line        13
                                              :started-at  three-milliseconds-later
-                                             :finished-at three-and-half-milliseconds-later}]
+                                             :finished-at four-milliseconds-later}]
                   'octocat.heavy-test      [{:context     ["First heavy test"]
                                              :id          "8a8e79c5-84aa-4846-b233-5969ec26a853"
-                                             :ns 'octocat.heavy-test
+                                             :ns          'octocat.heavy-test
                                              :file        heavy-test-file
                                              :line        5
                                              :started-at  three-milliseconds-later
                                              :finished-at nine-milliseconds-later}
                                             {:context     ["First heavy test"]
                                              :id          "8a8e79c5-84aa-4846-b233-5969ec26a853"
-                                             :ns 'octocat.heavy-test
+                                             :ns          'octocat.heavy-test
                                              :file        heavy-test-file
                                              :line        7
                                              :started-at  three-milliseconds-later
                                              :finished-at ten-milliseconds-later}
                                             {:context ["I don't have a duration"]
                                              :id      "0f9878b3-4d28-484d-9b98-a61ef53f4f89"
-                                             :ns 'octocat.heavy-test}
+                                             :ns      'octocat.heavy-test}
                                             {:context ["I don't have a duration too"]
                                              :id      "2f965b08-3508-43df-969b-274a0a360009"
-                                             :ns 'octocat.heavy-test}
+                                             :ns      'octocat.heavy-test}
                                             {:context     ["second heavy test"]
                                              :id          "12160c1a-4d4a-4d8d-8870-72243ee9539e"
-                                             :ns 'octocat.heavy-test
+                                             :ns          'octocat.heavy-test
                                              :file        heavy-test-file
                                              :line        12
                                              :started-at  ten-milliseconds-later
@@ -93,8 +96,10 @@
 
 (def test-results (profiler/distinct-results-with-known-durations report-map))
 
+(def total-time (misc/duration-between start-point thirteen-milliseconds-later))
+
 (defn fake-runner [_]
-  (Thread/sleep (.toMillis (misc/duration-between start-point thirteen-milliseconds-later)))
+  (Thread/sleep (.toMillis total-time))
   report-map)
 
 (def duration? #(instance? Duration %))
@@ -108,72 +113,69 @@
                 (Duration/ofMillis 6537)     "6.54 seconds"
                 (Duration/ofMinutes 4)     "4.00 minutes")
 
-       (fact "computes the duration of tests for each namespace"
-             (profiler/duration-per-ns test-results)
-             => {'octocat.arithmetic-test  (misc/duration-between start-point three-and-half-milliseconds-later)
-                 'octocat.heavy-test (misc/duration-between three-milliseconds-later thirteen-milliseconds-later)})
+       (fact "given the total time of the test suite and the number of tests in
+       that suite, returns the average time taken by each test"
+             (profiler/average (misc/duration-between start-point ten-milliseconds-later) 10)
+             => (misc/duration-between start-point one-millisecond-later))
 
-       (fact "returns information about the fastest test in the test results"
-             (profiler/top-fastest-tests 1 test-results)
-             => [{:context  ["fourth arithmetic test"]
-                  :file     arithmetic-test-file
-                  :line     13
-                  :duration (misc/duration-between three-milliseconds-later three-and-half-milliseconds-later)}])
+       (fact "returns a zeroed duration when the number of tests is zero"
+             (profiler/average (Duration/ZERO) 0)
+             => (Duration/ZERO))
 
-       (fact "returns information about the slowest test in the test results"
-             (profiler/top-slowest-tests 1 test-results)
-             => [{:context  ["First heavy test"]
-                  :file     heavy-test-file
-                  :line     7
-                  :duration (misc/duration-between three-milliseconds-later ten-milliseconds-later)}])
+       (fact "produces profile statistics for each namespace"
+             (profiler/stats-per-ns test-results total-time)
+             => [{:ns                    'octocat.heavy-test
+                  :total-time            (millis->duration 10)
+                  :percent-of-total-time "76.92%"
+                  :average               (millis->duration 5)
+                  :number-of-tests       2}
+                 {:ns                    'octocat.arithmetic-test
+                  :percent-of-total-time "30.77%"
+                  :total-time            (millis->duration 4)
+                  :average               (millis->duration 1)
+                  :number-of-tests       4}])
 
        (fact "returns information about the top n slowest tests in the test results"
              (profiler/top-slowest-tests 2 test-results)
-             => [{:context  ["First heavy test"]
-                  :file     heavy-test-file
-                  :line     7
-                  :duration (misc/duration-between three-milliseconds-later ten-milliseconds-later)}
-                 {:context  ["second heavy test"]
-                  :file     heavy-test-file
-                  :line     12
-                  :duration (misc/duration-between ten-milliseconds-later
-                                                   thirteen-milliseconds-later)}])
+             => [{:context    ["First heavy test"]
+                  :file       heavy-test-file
+                  :line       7
+                  :total-time (millis->duration 7)}
+                 {:context    ["second heavy test"]
+                  :file       heavy-test-file
+                  :line       12
+                  :total-time (millis->duration 3)}])
 
-       (fact "calculates the average of the duration of tests according to the supplied information"
-             (profiler/average (misc/duration-between start-point ten-milliseconds-later) 10)
-             => {:duration (misc/duration-between start-point one-millisecond-later)
-                 :tests 10})
+       (fact "returns statistics about the time consumed by the supplied test results"
+             (profiler/time-consumption (take 4 test-results) (millis->duration 13))
+             => {:total-time            (millis->duration 4)
+                 :percent-of-total-time "30.77%"})
 
-       (fact "returns zeroed values when the number of tests is zero"
-             (profiler/average (misc/duration-between start-point one-millisecond-later) 0)
-             => {:duration (Duration/ZERO)
-                 :tests 0})
-
-       (fact "wraps a runner by adding profiling information to the returned report data"
-             ((profiler/profiling fake-runner) {:profiling? true})
-             => (match {:profiling
-                        {:average {:duration duration?
-                                   :tests 6}
-                         :duration-per-ns {'octocat.arithmetic-test duration?
-                                           'octocat.heavy-test duration?}
-                         :fastest-tests [{:context  ["fourth arithmetic test"]
-                                          :line     13
-                                          :duration duration?}]
-                         :slowest-tests [{:context  ["First heavy test"]
-                                          :line     7
-                                          :duration duration?}]}
+       (fact "wraps a runner function by adding profiling information to the returned report data"
+             ((profiler/profile fake-runner) {:profile? true})
+             => (match {:profile
+                        {:average         duration?
+                         :total-time      duration?
+                         :number-of-tests 6
+                         :top-slowest-tests
+                         {:tests                 [{:context    ["First heavy test"]
+                                                   :line       7
+                                                   :total-time duration?}]
+                          :total-time            duration?
+                          :percent-of-total-time string?}
+                         :namespaces
+                         [{:ns 'octocat.heavy-test}
+                          {:ns 'octocat.arithmetic-test}]}
                         :summary {:finished-in duration?}}))
 
-       (fact "by default, the profiler/profiling only adds the total elapsed
+       (fact "by default, the profiler/profile only adds the total elapsed
              time to the summary map"
-             (let [{:keys [profiling summary]} ((profiler/profiling fake-runner) {})]
-               profiling => nil
+             (let [{:keys [profile summary]} ((profiler/profile fake-runner) {})]
+               profile => nil
                (:finished-in summary) => duration?))
 
-       (fact "users can customize the number of fastest and/or slowest tests returned"
-             ((profiler/profiling fake-runner) {:profiling? true
-                                                :fastest-tests 2
-                                                :slowest-tests 3})
-             => (match {:profiling
-                        {:fastest-tests #(= (count %) 2)
-                         :slowest-tests #(= (count %) 3)}})))
+       (fact "users can customize the number of slowest tests returned"
+             ((profiler/profile fake-runner) {:profile?      true
+                                              :slowest-tests 3})
+             => (match {:profile
+                        {:top-slowest-tests {:tests #(= (count %) 3)}}})))

--- a/test/midje_nrepl/profiler_test.clj
+++ b/test/midje_nrepl/profiler_test.clj
@@ -1,0 +1,67 @@
+(ns midje-nrepl.profiler-test
+  (:require [clojure.java.io :as io]
+            [midje-nrepl.misc :as misc]
+            [midje-nrepl.profiler :as profiler]
+            [midje.sweet :refer :all])
+  (:import java.time.LocalDateTime))
+
+(defn local-date-time [seconds]
+  (LocalDateTime/of 2019 01 01 12 0 seconds))
+
+(defn plus-seconds [time seconds]
+  (.plusSeconds time seconds))
+
+(def start-point (local-date-time 0))
+
+(def one-second-later (plus-seconds start-point 1))
+
+(def two-seconds-later (plus-seconds start-point 2))
+
+(def three-seconds-later (plus-seconds start-point 3))
+
+(def ten-seconds-later (plus-seconds start-point 10))
+
+(def thirteen-seconds-later (plus-seconds start-point 13))
+
+(def arithmetic-test-file (io/file "/home/john-doe/projects/octocat/test/octocat/arithmetic_test.clj"))
+
+(def heavy-test-file (io/file "/home/john-doe/projects/octocat/test/octocat/heavy_test.clj"))
+
+(def report-map {:results
+                 {'octocat.arithmetic-test [{:context     ["First arithmetic test"]
+                                             :file        arithmetic-test-file
+                                             :line        5
+                                             :started-at  start-point
+                                             :finished-at one-second-later}
+                                            {:context ["I am a future fact"]}
+                                            {:context     ["second arithmetic test"]
+                                             :file        arithmetic-test-file
+                                             :line        8
+                                             :started-at  one-second-later
+                                             :finished-at two-seconds-later}
+                                            {:context     ["third arithmetic test"]
+                                             :file        arithmetic-test-file
+                                             :line        10
+                                             :started-at  two-seconds-later
+                                             :finished-at three-seconds-later}]
+                  'octocat.heavy-test      [{:context     ["First heavy test"]
+                                             :file        heavy-test-file
+                                             :line        5
+                                             :started-at  three-seconds-later
+                                             :finished-at ten-seconds-later}
+                                            {:context ["I don't have a duration"]}
+                                            {:context ["I don't have a duration too"]}
+                                            {:context     ["second heavy test"]
+                                             :file        heavy-test-file
+                                             :line        8
+                                             :started-at  ten-seconds-later
+                                             :finished-at thirteen-seconds-later}]}})
+
+(facts "about the profiler"
+
+       (fact "computes the duration of tests for each namespace"
+             (profiler/duration-per-namespace report-map)
+             => [{:ns       'octocat.arithmetic-test
+                  :duration (misc/duration-between start-point three-seconds-later)}
+                 {:ns       'octocat.heavy-test
+                  :duration (misc/duration-between three-seconds-later thirteen-seconds-later)}]))

--- a/test/midje_nrepl/profiler_test.clj
+++ b/test/midje_nrepl/profiler_test.clj
@@ -4,7 +4,7 @@
             [midje-nrepl.misc :as misc]
             [midje-nrepl.profiler :as profiler]
             [midje.sweet :refer :all])
-  (:import java.time.LocalDateTime))
+  (:import (java.time Duration LocalDateTime)))
 
 (defn local-date-time [seconds]
   (LocalDateTime/of 2019 01 01 12 0 seconds))
@@ -98,4 +98,11 @@
                  {:context  ["second heavy test"]
                   :file     heavy-test-file
                   :line     12
-                  :duration (misc/duration-between ten-seconds-later thirteen-seconds-later)}]))
+                  :duration (misc/duration-between ten-seconds-later thirteen-seconds-later)}])
+
+       (tabular (fact "returns a friendly string representing the duration in question"
+                             (profiler/duration->string ?duration) => ?result)
+                        ?duration            ?result
+          (Duration/ofMillis 256) "256 milliseconds"
+         (Duration/ofMillis 6537)     "6.54 seconds"
+           (Duration/ofMinutes 4)     "4.00 minutes"))

--- a/test/midje_nrepl/profiler_test.clj
+++ b/test/midje_nrepl/profiler_test.clj
@@ -144,7 +144,12 @@
              => {:duration (misc/duration-between start-point one-millisecond-later)
                  :tests 10})
 
-       (fact ""
+       (fact "returns zeroed values when the number of tests is zero"
+             (profiler/average (misc/duration-between start-point one-millisecond-later) 0)
+             => {:duration (Duration/ZERO)
+                 :tests 0})
+
+       (fact "wraps a runner by adding profiling information to the returned report data"
              ((profiler/profiling fake-runner) {})
              => (match {:profiling
                         {:average {:duration duration?

--- a/test/midje_nrepl/profiler_test.clj
+++ b/test/midje_nrepl/profiler_test.clj
@@ -20,6 +20,8 @@
 
 (def three-seconds-later (plus-seconds start-point 3))
 
+(def nine-and-half-seconds-later (plus-seconds start-point 9.5))
+
 (def ten-seconds-later (plus-seconds start-point 10))
 
 (def thirteen-seconds-later (plus-seconds start-point 13))
@@ -30,31 +32,44 @@
 
 (def report-map {:results
                  {'octocat.arithmetic-test [{:context     ["First arithmetic test"]
+                                             :id          "20208edc-4129-4511-be13-38c9a8e28480"
                                              :file        arithmetic-test-file
                                              :line        5
                                              :started-at  start-point
                                              :finished-at one-second-later}
                                             {:context ["I am a future fact"]}
                                             {:context     ["second arithmetic test"]
+                                             :id          "021a8d7f-e546-42e4-8c70-da4fcc7be6b4"
                                              :file        arithmetic-test-file
                                              :line        8
                                              :started-at  one-second-later
                                              :finished-at two-seconds-later}
                                             {:context     ["third arithmetic test"]
+                                             :id          "b64ac1c8-ff83-4785-8cec-9c180609cb9f"
                                              :file        arithmetic-test-file
                                              :line        10
                                              :started-at  two-seconds-later
                                              :finished-at three-seconds-later}]
                   'octocat.heavy-test      [{:context     ["First heavy test"]
+                                             :id          "8a8e79c5-84aa-4846-b233-5969ec26a853"
                                              :file        heavy-test-file
                                              :line        5
                                              :started-at  three-seconds-later
-                                             :finished-at ten-seconds-later}
-                                            {:context ["I don't have a duration"]}
-                                            {:context ["I don't have a duration too"]}
-                                            {:context     ["second heavy test"]
+                                             :finished-at nine-and-half-seconds-later}
+                                            {:context     ["First heavy test"]
+                                             :id          "8a8e79c5-84aa-4846-b233-5969ec26a853"
                                              :file        heavy-test-file
-                                             :line        8
+                                             :line        7
+                                             :started-at  three-seconds-later
+                                             :finished-at ten-seconds-later}
+                                            {:context ["I don't have a duration"]
+                                             :id      "0f9878b3-4d28-484d-9b98-a61ef53f4f89"}
+                                            {:context ["I don't have a duration too"]
+                                             :id      "2f965b08-3508-43df-969b-274a0a360009"}
+                                            {:context     ["second heavy test"]
+                                             :id          "12160c1a-4d4a-4d8d-8870-72243ee9539e"
+                                             :file        heavy-test-file
+                                             :line        12
                                              :started-at  ten-seconds-later
                                              :finished-at thirteen-seconds-later}]}})
 
@@ -71,5 +86,16 @@
              (profiler/top-slowest-tests 1 report-map)
              => [{:context  ["First heavy test"]
                   :file     heavy-test-file
-                  :line     5
-                  :duration (misc/duration-between three-seconds-later ten-seconds-later)}]))
+                  :line     7
+                  :duration (misc/duration-between three-seconds-later ten-seconds-later)}])
+
+       (fact "returns information about the top n slowest tests in the report map"
+             (profiler/top-slowest-tests 2 report-map)
+             => [{:context  ["First heavy test"]
+                  :file     heavy-test-file
+                  :line     7
+                  :duration (misc/duration-between three-seconds-later ten-seconds-later)}
+                 {:context  ["second heavy test"]
+                  :file     heavy-test-file
+                  :line     12
+                  :duration (misc/duration-between ten-seconds-later thirteen-seconds-later)}]))

--- a/test/midje_nrepl/profiler_test.clj
+++ b/test/midje_nrepl/profiler_test.clj
@@ -150,7 +150,7 @@
                  :tests 0})
 
        (fact "wraps a runner by adding profiling information to the returned report data"
-             ((profiler/profiling fake-runner) {})
+             ((profiler/profiling fake-runner) {:profiling? true})
              => (match {:profiling
                         {:average {:duration duration?
                                    :tests 6}
@@ -162,5 +162,18 @@
                          :slowest-tests [{:context  ["First heavy test"]
                                           :line     7
                                           :duration duration?}]}
-                        :summary {:finished-in duration?}})
-             ))
+                        :summary {:finished-in duration?}}))
+
+       (fact "by default, the profiler/profiling only adds the total elapsed
+             time to the summary map"
+             (let [{:keys [profiling summary]} ((profiler/profiling fake-runner) {})]
+               profiling => nil
+               (:finished-in summary) => duration?))
+
+       (fact "users can customize the number of fastest and/or slowest tests returned"
+             ((profiler/profiling fake-runner) {:profiling? true
+                                                :fastest-tests 2
+                                                :slowest-tests 3})
+             => (match {:profiling
+                        {:fastest-tests #(= (count %) 2)
+                         :slowest-tests #(= (count %) 3)}})))

--- a/test/midje_nrepl/profiler_test.clj
+++ b/test/midje_nrepl/profiler_test.clj
@@ -1,5 +1,6 @@
 (ns midje-nrepl.profiler-test
   (:require [clojure.java.io :as io]
+            [matcher-combinators.midje :refer [match]]
             [midje-nrepl.misc :as misc]
             [midje-nrepl.profiler :as profiler]
             [midje.sweet :refer :all])
@@ -64,4 +65,11 @@
              => [{:ns       'octocat.arithmetic-test
                   :duration (misc/duration-between start-point three-seconds-later)}
                  {:ns       'octocat.heavy-test
-                  :duration (misc/duration-between three-seconds-later thirteen-seconds-later)}]))
+                  :duration (misc/duration-between three-seconds-later thirteen-seconds-later)}])
+
+       (fact "returns information about the slowest test in the report map"
+             (profiler/top-slowest-tests 1 report-map)
+             => [{:context  ["First heavy test"]
+                  :file     heavy-test-file
+                  :line     5
+                  :duration (misc/duration-between three-seconds-later ten-seconds-later)}]))

--- a/test/midje_nrepl/reporter_test.clj
+++ b/test/midje_nrepl/reporter_test.clj
@@ -6,7 +6,7 @@
             [midje.emission.api :refer [silently]]
             [midje.sweet :refer :all]
             [midje.util.exceptions :as midje.exceptions])
-  (:import java.time.LocalDateTime))
+  (:import java.time.Instant))
 
 (def correct-fact-function (with-meta (constantly true)
                              #:midje {:guid            "d2cd94c3346922886e796da80ab99ab764ba30f9"
@@ -294,8 +294,8 @@ it is interpreted as an error in the test report"
                   first
                   (remove #(= (:type %) :to-do))
                   (every? (fn [{:keys [started-at finished-at]}]
-                            (and (instance? LocalDateTime started-at)
-                                 (instance? LocalDateTime finished-at)))))
+                            (and (instance? Instant started-at)
+                                 (instance? Instant finished-at)))))
              => true)
 
        (fact "future facts don't contain the neither the `:started-at` nor the `finished-at` keys"


### PR DESCRIPTION
As of this pull request `midje-nrepl` can collect profiling statistics about
tests. By default, only the total time taken by the test suite is returned by
the middleware. By sending the parameter `profile?`, clients can enable more
detailed profiling information, including the average time taken by the test
suite as well by each namespace, the time consumed by each namespace in relation
to the total time and some information about the top n (where n is a
configurable number) slowest tests.